### PR TITLE
SendGrid email sender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,21 @@ script:
   - black --check functions main.py --target-version=py36
 
 deploy:
+  # Staging functions
   - provider: script
     script: bash deploy/pubsub.sh ingest_upload uploads .env.staging.yaml
     on:
       branch: master
   - provider: script
+    script: bash deploy/pubsub.sh send_email emails .env.staging.yaml
+    on:
+      branch: master
+  # Production functions
+  - provider: script
     script: bash deploy/pubsub.sh ingest_upload uploads .env.prod.yaml
+    on:
+      branch: production
+  - provider: script
+    script: bash deploy/pubsub.sh send_email emails .env.prod.yaml
     on:
       branch: production

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Google Cloud Functions for carrying out event-driven tasks in the CIDC.
 
 - Pub/Sub-triggered:
   - `ingest_upload`: when a successful upload job is published to the "uploads" topic, transfers data from the upload bucket to the data bucket in GCS.
+  - `send_email`: when an email is published to the "emails" topic, sends the email using the SendGrid API.
 
 ## Development
 

--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,3 +1,4 @@
 """The CIDC cloud functions."""
 
 from .uploads import ingest_upload
+from .emails import send_email

--- a/functions/emails.py
+++ b/functions/emails.py
@@ -1,0 +1,40 @@
+"""Functions for interacting with the Sendgrid API"""
+import json
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+from .settings import SENDGRID_API_KEY
+from .util import BackgroundContext, extract_pubsub_data
+
+FROM_EMAIL = "no-reply@cimac-network.org"
+
+_sg = None
+
+
+def _get_sg_client() -> SendGridAPIClient:
+    global _sg
+    if not _sg:
+        _sg = SendGridAPIClient(SENDGRID_API_KEY)
+    return _sg
+
+
+def send_email(event: dict, context: BackgroundContext):
+    """Send an email using the SendGrid API."""
+    email = json.loads(extract_pubsub_data(event))
+
+    # Validate that the email blob has the expected structure
+    assert "to_emails" in email
+    assert "subject" in email
+    assert "html_content" in email
+    assert len(email) == 3  # no extra keys
+
+    message = Mail(from_email=FROM_EMAIL, **email)
+
+    print(f"Sending email: {email}")
+
+    sg = _get_sg_client()
+    response = sg.send(message)
+
+    print(f"Email status code: {response.status_code}")
+    print(f"Email response body: {response.body}")

--- a/functions/settings.py
+++ b/functions/settings.py
@@ -1,7 +1,8 @@
 """Configuration for CIDC functions."""
 import os
 
-from cidc_api.config import get_sqlalchemy_database_uri
+from cidc_api.config import get_sqlalchemy_database_uri, get_secret_manager
+
 
 # Cloud Functions provide the current GCP project id
 # in the environment variable GCP_PROJECT. If this
@@ -15,9 +16,13 @@ if not GCP_PROJECT:
     load_dotenv()
 
 TESTING = os.environ.get("TESTING")
+secrets = get_secret_manager(TESTING)
+
 SQLALCHEMY_DATABASE_URI = get_sqlalchemy_database_uri(TESTING)
 GOOGLE_UPLOAD_BUCKET = os.environ.get("GOOGLE_UPLOAD_BUCKET")
 GOOGLE_DATA_BUCKET = os.environ.get("GOOGLE_DATA_BUCKET")
+
+SENDGRID_API_KEY = secrets.get("SENDGRID_API_KEY")
 
 # Check for configuration that must be defined if we're running in GCP
 if GCP_PROJECT:

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -1,6 +1,4 @@
 """A pub/sub triggered functions that respond to data upload events"""
-import base64
-
 from flask import jsonify
 from google.cloud import storage
 from cidc_api.models import UploadJobs

--- a/main.py
+++ b/main.py
@@ -1,3 +1,3 @@
 """Entrypoint for CIDC cloud functions."""
 
-from functions import ingest_upload
+from functions import ingest_upload, send_email

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ flask==1.1.1
 flask-sqlalchemy==2.4.0
 google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
+sendgrid==6.0.5
 # The cidc_api_modules package
 cidc-api-modules==0.1.0

--- a/tests/functions/test_emails.py
+++ b/tests/functions/test_emails.py
@@ -1,0 +1,37 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from sendgrid.helpers.mail import Mail
+
+
+from functions import emails
+from tests.util import make_pubsub_event
+
+
+def test_send_email(monkeypatch):
+    """Test that the email sending function builds a message as expected."""
+    sender = MagicMock()
+    sg_client = MagicMock()
+    sg_client.return_value = sender
+    monkeypatch.setattr(emails, "_get_sg_client", sg_client)
+
+    # Well-formed email
+    email = {
+        "to_emails": ["foo@bar.com", "bar@foo.org"],
+        "subject": "test subject",
+        "html_content": "test content",
+    }
+    event = make_pubsub_event(json.dumps(email))
+    emails.send_email(event, None)
+    args, _ = sender.send.call_args
+    message = args[0]
+    # A SendGrid message's string representation is a JSON blob
+    # detailing its configuration.
+    assert str(message) == str(Mail(from_email=emails.FROM_EMAIL, **email))
+
+    # Malformed email
+    del email["subject"]
+    event = make_pubsub_event(json.dumps(email))
+    with pytest.raises(AssertionError):
+        emails.send_email(event, None)


### PR DESCRIPTION
Adds a new cloud function, `functions.emails.send_email`, that sends an email published to the Pub/Sub `emails` topic using the SendGrid API.