### PR TITLE
Add GCS object URLs and merge assay metadata in ingest_upload

### DIFF
--- a/.env.prod.yaml
+++ b/.env.prod.yaml
@@ -1,5 +1,5 @@
-CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci:us-central1:cidc-postgres'
-CLOUD_SQL_DB_USER: 'postgres'
+CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci:us-central1:cidc-postgresql'
+CLOUD_SQL_DB_USER: 'cidcuser'
 CLOUD_SQL_DB_NAME: 'cidc'
 GOOGLE_SECRETS_BUCKET: 'cidc-secrets-prod'
 GOOGLE_UPLOAD_BUCKET: 'cidc-uploads-prod'

--- a/.env.staging.yaml
+++ b/.env.staging.yaml
@@ -1,5 +1,5 @@
-CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci-staging:us-central1:cidc-postgres'
-CLOUD_SQL_DB_USER: 'postgres'
+CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci-staging:us-central1:cidc-postgresql'
+CLOUD_SQL_DB_USER: 'cidcuser'
 CLOUD_SQL_DB_NAME: 'cidc'
 GOOGLE_SECRETS_BUCKET: 'cidc-secrets-staging'
 GOOGLE_UPLOAD_BUCKET: 'cidc-uploads-staging'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
 cidc-api-modules==0.1.0
+cidc-schemas==0.1.4


### PR DESCRIPTION
Now, `ingest_upload` adds GCS object URLs to assay metadata and merges that updated metadata into the existing assay metadata object for that trial using `TrialMetadata.patch_trial_metadata`.