### PR TITLE
Bump cidc-api-modules version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules==0.1.0
+cidc-api-modules==0.1.1
 cidc-schemas==0.1.4


### PR DESCRIPTION
...one reason why using the API rather than access the database directly might be favorable.