### PR TITLE
Save file metadata to downloadable_files table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules==0.1.2
-cidc-schemas==0.1.4
+cidc-api-modules==0.1.4
+cidc-schemas==0.1.5

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from cidc_api.models import UploadJobs, TrialMetadata
+from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
 
 from tests.util import make_pubsub_event, with_app_context
 from functions.uploads import ingest_upload
@@ -15,6 +15,7 @@ def test_ingest_upload(db_session, monkeypatch):
     URI2 = "/path/to/deeper/file2"
     TS_AND_PATH = "/1234/local_path1.txt"
     FILE_URIS = [URI1 + TS_AND_PATH, URI2 + TS_AND_PATH]
+    ARTIFACT = {"test-prop": "test-val"}
 
     job = UploadJobs(
         id=JOB_ID,
@@ -33,12 +34,15 @@ def test_ingest_upload(db_session, monkeypatch):
 
     # Mock data transfer functionality
     _copy_gcs_object = MagicMock()
-    _copy_gcs_object.return_value = job.metadata_json_patch
+    _copy_gcs_object.return_value = job.metadata_json_patch, ARTIFACT
     monkeypatch.setattr(
         "functions.uploads._copy_gcs_object_and_update_metadata", _copy_gcs_object
     )
 
     # Mock metadata merging functionality
+    _save_file = MagicMock()
+    monkeypatch.setattr(DownloadableFiles, "create_from_metadata", _save_file)
+
     _merge_metadata = MagicMock()
     monkeypatch.setattr(TrialMetadata, "patch_trial_metadata", _merge_metadata)
 
@@ -50,5 +54,7 @@ def test_ingest_upload(db_session, monkeypatch):
     find_by_id.assert_called_once_with(JOB_ID, session=db_session)
     # Check that we copied multiple objects
     _copy_gcs_object.assert_called() and not _copy_gcs_object.assert_called_once()
+    # Check that we tried to save multiple files
+    _save_file.assert_called() and not _save_file.assert_called_once()
     # Check that we tried to merge metadata once
     _merge_metadata.assert_called_once()


### PR DESCRIPTION
Use https://github.com/CIMAC-CIDC/cidc-api-gae/pull/42 to save metadata for ingested files to the `downloadable_files` table.