### PR TITLE
Share sqlalchemy engine, not session, across function invocations

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -13,8 +13,6 @@ def ingest_upload(event: dict, context: BackgroundContext):
     When a successful upload event is published, move the data associated
     with the upload job into the download bucket and merge the upload metadata
     into the appropriate clinical trial JSON.
-
-    TODO: actually implement the above functionality.
     """
     job_id = int(extract_pubsub_data(event))
     session = get_db_session()

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -5,7 +5,7 @@ from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
 from cidc_schemas import prism
 
 from .settings import GOOGLE_DATA_BUCKET, GOOGLE_UPLOAD_BUCKET
-from .util import BackgroundContext, extract_pubsub_data, get_db_session
+from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
 
 
 def ingest_upload(event: dict, context: BackgroundContext):
@@ -15,58 +15,60 @@ def ingest_upload(event: dict, context: BackgroundContext):
     into the appropriate clinical trial JSON.
     """
     job_id = int(extract_pubsub_data(event))
-    session = get_db_session()
 
-    job: UploadJobs = UploadJobs.find_by_id(job_id, session=session)
+    with sqlalchemy_session() as session:
+        job: UploadJobs = UploadJobs.find_by_id(job_id, session=session)
 
-    print("Detected completed upload job for user %s" % job.uploader_email)
+        print("Detected completed upload job for user %s" % job.uploader_email)
 
-    trial_id_field = "lead_organization_study_id"
-    if not trial_id_field in job.metadata_json_patch:
-        # We should never hit this. This function should only be called on pre-validated metadata.
-        raise Exception(
-            "Invalid metadata: cannot find study ID in metadata. Aborting ingestion."
+        trial_id_field = "lead_organization_study_id"
+        if not trial_id_field in job.metadata_json_patch:
+            # We should never hit this. This function should only be called on pre-validated metadata.
+            raise Exception(
+                "Invalid metadata: cannot find study ID in metadata. Aborting ingestion."
+            )
+        trial_id = job.metadata_json_patch[trial_id_field]
+
+        url_mapping = {}
+        metadata_with_urls = job.metadata_json_patch
+        downloadable_files = []
+        for upload_url in job.gcs_file_uris:
+            # We expected URIs in the upload bucket to have a structure like
+            # [trial id]/[patient id]/[sample id]/[aliquot id]/[timestamp]/[local file].
+            # We strip off the /[timestamp]/[local file] suffix from the upload url,
+            # since we don't care when this was uploaded or where from on the uploader's
+            # computer.
+            target_url = "/".join(upload_url.split("/")[:-2])
+            url_mapping[upload_url] = target_url
+
+            # Copy the uploaded GCS object to the data bucket
+            metadata_with_urls, artifact_metadata = _copy_gcs_object_and_update_metadata(
+                job.assay_type,
+                metadata_with_urls,
+                GOOGLE_UPLOAD_BUCKET,
+                upload_url,
+                GOOGLE_DATA_BUCKET,
+                target_url,
+            )
+
+            # Hang on to the artifact metadata
+            downloadable_files.append(artifact_metadata)
+
+        # Add metadata for this upload to the database
+        print("Merging metadata from upload %d into trial %s" % (job.id, trial_id))
+        TrialMetadata.patch_trial_metadata(
+            trial_id, metadata_with_urls, session=session
         )
-    trial_id = job.metadata_json_patch[trial_id_field]
 
-    url_mapping = {}
-    metadata_with_urls = job.metadata_json_patch
-    downloadable_files = []
-    for upload_url in job.gcs_file_uris:
-        # We expected URIs in the upload bucket to have a structure like
-        # [trial id]/[patient id]/[sample id]/[aliquot id]/[timestamp]/[local file].
-        # We strip off the /[timestamp]/[local file] suffix from the upload url,
-        # since we don't care when this was uploaded or where from on the uploader's
-        # computer.
-        target_url = "/".join(upload_url.split("/")[:-2])
-        url_mapping[upload_url] = target_url
-
-        # Copy the uploaded GCS object to the data bucket
-        metadata_with_urls, artifact_metadata = _copy_gcs_object_and_update_metadata(
-            job.assay_type,
-            metadata_with_urls,
-            GOOGLE_UPLOAD_BUCKET,
-            upload_url,
-            GOOGLE_DATA_BUCKET,
-            target_url,
-        )
-
-        # Hang on to the artifact metadata
-        downloadable_files.append(artifact_metadata)
-
-    # Add metadata for this upload to the database
-    print("Merging metadata from upload %d into trial %s" % (job.id, trial_id))
-    TrialMetadata.patch_trial_metadata(trial_id, metadata_with_urls, session=session)
-
-    # Save downloadable files to the database
-    # NOTE: this needs to happen after TrialMetadata.patch_trial_metadata
-    # in order to avoid violating a foreign-key constraint on the trial_id
-    # in the event that this is the first upload for a trial.
-    for artifact_metadata in downloadable_files:
-        print(f"Saving metadata for {target_url} to downloadable_files table.")
-        DownloadableFiles.create_from_metadata(
-            trial_id, job.assay_type, artifact_metadata, session=session
-        )
+        # Save downloadable files to the database
+        # NOTE: this needs to happen after TrialMetadata.patch_trial_metadata
+        # in order to avoid violating a foreign-key constraint on the trial_id
+        # in the event that this is the first upload for a trial.
+        for artifact_metadata in downloadable_files:
+            print(f"Saving metadata for {target_url} to downloadable_files table.")
+            DownloadableFiles.create_from_metadata(
+                trial_id, job.assay_type, artifact_metadata, session=session
+            )
 
     # Google won't actually do anything with this response; it's
     # provided for testing purposes only.

--- a/functions/util.py
+++ b/functions/util.py
@@ -1,5 +1,6 @@
 """Helpers for working with Cloud Functions."""
 import base64
+from contextlib import contextmanager
 from typing import NamedTuple
 
 from sqlalchemy import create_engine
@@ -10,22 +11,22 @@ from .settings import SQLALCHEMY_DATABASE_URI
 _engine = None
 
 
-class sqlalchemy_session:
+@contextmanager
+def sqlalchemy_session():
     """Get a SQLAlchemy session from the connection pool"""
+    global _engine
+    if not _engine:
+        _engine = create_engine(SQLALCHEMY_DATABASE_URI)
+    session = sessionmaker(bind=_engine)()
 
-    def __init__(self):
-        global _engine
-
-        if not _engine:
-            _engine = create_engine(SQLALCHEMY_DATABASE_URI)
-
-        self.session = sessionmaker(bind=_engine)()
-
-    def __enter__(self):
-        return self.session
-
-    def __exit__(self, type, value, traceback):
-        self.session.close()
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def extract_pubsub_data(event: dict):

--- a/functions/util.py
+++ b/functions/util.py
@@ -10,14 +10,22 @@ from .settings import SQLALCHEMY_DATABASE_URI
 _engine = None
 
 
-def get_db_session():
-    """Get the current SQLAlchemy session"""
-    global _engine
+class sqlalchemy_session:
+    """Get a SQLAlchemy session from the connection pool"""
 
-    if not _engine:
-        _engine = create_engine(SQLALCHEMY_DATABASE_URI)
+    def __init__(self):
+        global _engine
 
-    return sessionmaker(bind=_engine)()
+        if not _engine:
+            _engine = create_engine(SQLALCHEMY_DATABASE_URI)
+
+        self.session = sessionmaker(bind=_engine)()
+
+    def __enter__(self):
+        return self.session
+
+    def __exit__(self, type, value, traceback):
+        self.session.close()
 
 
 def extract_pubsub_data(event: dict):

--- a/functions/util.py
+++ b/functions/util.py
@@ -7,18 +7,17 @@ from sqlalchemy.orm import sessionmaker
 
 from .settings import SQLALCHEMY_DATABASE_URI
 
-_session = None
+_engine = None
 
 
 def get_db_session():
     """Get the current SQLAlchemy session"""
-    global _session
+    global _engine
 
-    if not _session:
-        engine = create_engine(SQLALCHEMY_DATABASE_URI)
-        _session = sessionmaker(bind=engine)()
+    if not _engine:
+        _engine = create_engine(SQLALCHEMY_DATABASE_URI)
 
-    return _session
+    return sessionmaker(bind=_engine)()
 
 
 def extract_pubsub_data(event: dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,4 @@ import os
 
 import pytest
 
-from functions.util import get_db_session
-
 os.environ["TESTING"] = "True"
-
-
-# TODO: set up database migrations for this project
-# so that tests can actually modify the test database instance.
-@pytest.fixture
-def db_session():
-    return get_db_session()

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -5,11 +5,12 @@ import datetime
 from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
 
 from tests.util import make_pubsub_event, with_app_context
+from functions import util
 from functions.uploads import ingest_upload
 
 
 @with_app_context
-def test_ingest_upload(db_session, monkeypatch):
+def test_ingest_upload(monkeypatch):
     """Test upload data transfer functionality"""
 
     JOB_ID = 1
@@ -75,7 +76,7 @@ def test_ingest_upload(db_session, monkeypatch):
 
     assert response.json[URI1 + TS_AND_PATH] == URI1
     assert response.json[URI2 + TS_AND_PATH] == URI2
-    find_by_id.assert_called_once_with(JOB_ID, session=db_session)
+    find_by_id.assert_called_once()
     # Check that we copied multiple objects
     _gcs_copy.assert_called() and not _gcs_copy.assert_called_once()
     # Check that we tried to save multiple files

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -5,7 +5,6 @@ import datetime
 from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
 
 from tests.util import make_pubsub_event, with_app_context
-from functions import util
 from functions.uploads import ingest_upload
 
 

--- a/tests/functions/test_util.py
+++ b/tests/functions/test_util.py
@@ -1,9 +1,47 @@
+from unittest.mock import MagicMock
+
 from tests.util import make_pubsub_event
-from functions.util import extract_pubsub_data
+from functions import util
 
 
 def test_extract_pubsub_data():
     """Ensure that extract_pubsub_data can do what it claims"""
     data = "hello there"
     event = make_pubsub_event(data)
-    assert extract_pubsub_data(event) == data
+    assert util.extract_pubsub_data(event) == data
+
+
+def test_sqlalchemy_session(monkeypatch):
+    """Check that the sqlalchemy context manager creates/closes a session on enter/exit"""
+    # Simulate function startup, when no SQLAlchemy _engine
+    # has yet been initialized.
+    util._engine = None
+
+    engine = MagicMock()
+    create_engine = MagicMock()
+    create_engine.return_value = engine
+    session = MagicMock()
+    session_creator = MagicMock()
+    session_creator.return_value = session
+    sessionmaker = MagicMock()
+    sessionmaker.return_value = session_creator
+
+    monkeypatch.setattr(util, "create_engine", create_engine)
+    monkeypatch.setattr(util, "sessionmaker", sessionmaker)
+
+    # On first invocation, we expect a global engine to be created
+    # and a session to be made.
+    with util.sqlalchemy_session() as sesh:
+        create_engine.assert_called_once()
+        sessionmaker.assert_called_once_with(bind=engine)
+        assert sesh == session
+
+    session.close.assert_called_once()
+
+    create_engine.reset_mock()
+    sessionmaker.reset_mock()
+
+    # On subsequent invocations, the already-created engine to be used.
+    with util.sqlalchemy_session() as sesh:
+        create_engine.assert_not_called()
+        sessionmaker.assert_called_once_with(bind=engine)


### PR DESCRIPTION
Hot fix: under certain circumstances, if a database transaction in a previous function invocation fails, the postgres error from that previous invocation might get thrown during the current invocation (even though it is unrelated). ~Rolling back the database session before using it flushes such errors, and prevents this from happening.~

**Update**: per @curlup's comment, this PR updated `get_db_session` to share a global sqlalchemy engine instance, but create a new session for every invocation of `get_db_session`.