### PR TITLE
Prism calls removed (moved to api code), upload/target gcs uri formatting moved to api

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -2,7 +2,6 @@
 from flask import jsonify
 from google.cloud import storage
 from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
-from cidc_schemas import prism
 
 from .settings import GOOGLE_DATA_BUCKET, GOOGLE_UPLOAD_BUCKET
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
@@ -32,19 +31,15 @@ def ingest_upload(event: dict, context: BackgroundContext):
         url_mapping = {}
         metadata_with_urls = job.metadata_json_patch
         downloadable_files = []
-        for upload_url in job.gcs_file_uris:
-            # We expected URIs in the upload bucket to have a structure like
-            # [trial id]/[patient id]/[sample id]/[aliquot id]/[timestamp]/[local file].
-            # We strip off the /[timestamp]/[local file] suffix from the upload url,
-            # since we don't care when this was uploaded or where from on the uploader's
-            # computer.
-            target_url = "/".join(upload_url.split("/")[:-2])
+        for upload_url, target_url, uuid in job.upload_uris_with_data_uris_with_uuids:
+            
             url_mapping[upload_url] = target_url
 
             # Copy the uploaded GCS object to the data bucket
             metadata_with_urls, artifact_metadata = _copy_gcs_object_and_update_metadata(
-                job.assay_type,
                 metadata_with_urls,
+                job.assay_type,
+                uuid,
                 GOOGLE_UPLOAD_BUCKET,
                 upload_url,
                 GOOGLE_DATA_BUCKET,
@@ -91,8 +86,9 @@ def _gcs_copy(
 
 
 def _copy_gcs_object_and_update_metadata(
-    assay_type: str,
     metadata: dict,
+    assay_type: str,
+    UUID: str,
     source_bucket: str,
     source_object: str,
     target_bucket: str,
@@ -103,13 +99,11 @@ def _copy_gcs_object_and_update_metadata(
     to_object = _gcs_copy(source_bucket, source_object, target_bucket, target_object)
 
     print(f"Adding artifact {to_object.name} to metadata.")
-    updated_trial_metadata, artifact_metadata = prism.merge_artifact(
+    updated_trial_metadata, artifact_metadata = TrialMetadata.merge_gcs_artifact(
         metadata,
         assay_type,
-        to_object.name,
-        to_object.size,
-        to_object.time_created.isoformat(),
-        to_object.md5_hash,
+        uuid,
+        to_object
     )
 
     return updated_trial_metadata, artifact_metadata

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -32,7 +32,7 @@ def ingest_upload(event: dict, context: BackgroundContext):
         metadata_with_urls = job.metadata_json_patch
         downloadable_files = []
         for upload_url, target_url, uuid in job.upload_uris_with_data_uris_with_uuids:
-            
+
             url_mapping[upload_url] = target_url
 
             # Copy the uploaded GCS object to the data bucket
@@ -100,10 +100,7 @@ def _copy_gcs_object_and_update_metadata(
 
     print(f"Adding artifact {to_object.name} to metadata.")
     updated_trial_metadata, artifact_metadata = TrialMetadata.merge_gcs_artifact(
-        metadata,
-        assay_type,
-        uuid,
-        to_object
+        metadata, assay_type, uuid, to_object
     )
 
     return updated_trial_metadata, artifact_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules==0.4.2
+cidc-api-modules==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules==0.4.1
+cidc-api-modules==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules==0.3.0
-cidc-schemas==0.3.0
+cidc-api-modules==0.4.1

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 from collections import namedtuple
 import datetime
 
-from cidc_api.models import UploadJobs, TrialMetadata, DownloadableFiles
+from cidc_api.models import AssayUploads, TrialMetadata, DownloadableFiles
 
 from tests.util import make_pubsub_event, with_app_context
 from functions.uploads import ingest_upload
@@ -16,14 +16,18 @@ def test_ingest_upload(monkeypatch):
     URI1 = "/path/to/file1"
     URI2 = "/path/to/deeper/file2"
     TS_AND_PATH = "/1234/local_path1.txt"
-    FILE_URIS = [URI1 + TS_AND_PATH, URI2 + TS_AND_PATH]
+    UPLOAD_DATE_PATH = '/2019-09-04T17:00:28.685967'
+    FILE_MAP = {
+        URI1+UPLOAD_DATE_PATH : "uuid1", 
+        URI2+UPLOAD_DATE_PATH : "uuid2"
+    }
     ARTIFACT = {"test-prop": "test-val"}
 
-    job = UploadJobs(
+    job = AssayUploads(
         id=JOB_ID,
         uploader_email="test@email.com",
-        gcs_file_uris=FILE_URIS,
-        metadata_json_patch={
+        gcs_file_map=FILE_MAP,
+        metadata={
             "lead_organization_study_id": "CIMAC-12345",
             "assays": {
                 "wes": [
@@ -49,14 +53,14 @@ def test_ingest_upload(monkeypatch):
     # store or retrieve data
     find_by_id = MagicMock()
     find_by_id.return_value = job
-    monkeypatch.setattr(UploadJobs, "find_by_id", find_by_id)
+    monkeypatch.setattr(AssayUploads, "find_by_id", find_by_id)
 
     # Mock data transfer functionality
     _gcs_copy = MagicMock()
     _gcs_copy.return_value = namedtuple(
         "gsc_object_mock", ["name", "size", "time_created", "md5_hash"]
     )(
-        "CIMAC-mock-pa-id/CIMAC-mock-sa-id/CIMAC-mock-al-id/wes/fastq_1/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "CIMAC-mock-pa-id/CIMAC-mock-sa-id/CIMAC-mock-al-id/wes/fastq_1",
         100,
         datetime.datetime.now(),
         "gsc_url_mock_hash",
@@ -71,10 +75,10 @@ def test_ingest_upload(monkeypatch):
     monkeypatch.setattr(TrialMetadata, "patch_trial_metadata", _merge_metadata)
 
     successful_upload_event = make_pubsub_event(str(job.id))
-    response = ingest_upload(successful_upload_event, None)
+    response = ingest_upload(successful_upload_event, None).json
 
-    assert response.json[URI1 + TS_AND_PATH] == URI1
-    assert response.json[URI2 + TS_AND_PATH] == URI2
+    assert response[URI1+UPLOAD_DATE_PATH] == URI1
+    assert response[URI2+UPLOAD_DATE_PATH] == URI2
     find_by_id.assert_called_once()
     # Check that we copied multiple objects
     _gcs_copy.assert_called() and not _gcs_copy.assert_called_once()


### PR DESCRIPTION
It breaks because it needs to be up to date with a corresponding api version - https://github.com/CIMAC-CIDC/cidc-api-gae/pull/62 
Don't now how to do that w/o api release.