### PR TITLE
Write assay upload merge status to the database

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -100,6 +100,7 @@ def ingest_upload(event: dict, context: BackgroundContext):
 
         # Save the upload success
         job.status = AssayUploadStatus.MERGE_COMPLETED.value
+        session.commit()
 
     # Google won't actually do anything with this response; it's
     # provided for testing purposes only.

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -1,10 +1,29 @@
 """A pub/sub triggered functions that respond to data upload events"""
+from contextlib import contextmanager
+
 from flask import jsonify
 from google.cloud import storage
-from cidc_api.models import AssayUploads, TrialMetadata, DownloadableFiles
+from cidc_api.models import (
+    AssayUploads,
+    TrialMetadata,
+    DownloadableFiles,
+    AssayUploadStatus,
+)
 
 from .settings import GOOGLE_DATA_BUCKET, GOOGLE_UPLOAD_BUCKET
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
+
+
+@contextmanager
+def saved_failure_status(job: AssayUploads, session):
+    """Save an upload failure to the database before raising an exception."""
+    try:
+        yield
+    except Exception as e:
+        job.status = AssayUploadStatus.MERGE_FAILED.value
+        job.status_details = str(e)
+        session.commit()
+        raise e
 
 
 def ingest_upload(event: dict, context: BackgroundContext):
@@ -17,16 +36,27 @@ def ingest_upload(event: dict, context: BackgroundContext):
 
     with sqlalchemy_session() as session:
         job: AssayUploads = AssayUploads.find_by_id(job_id, session=session)
+        if not job:
+            raise Exception(f"No assay upload job with id {job_id} found.")
+
+        # Ensure this is a completed upload and nothing else
+        if AssayUploadStatus(job.status) != AssayUploadStatus.UPLOAD_COMPLETED:
+            raise Exception(
+                f"Received ID for job with status {job.status}. Aborting ingestion."
+            )
 
         print("Detected completed upload job for user %s" % job.uploader_email)
 
-        trial_id_field = "lead_organization_study_id"
-        if not trial_id_field in job.assay_patch:
-            # We should never hit this. This function should only be called on pre-validated metadata.
+        trial_id = job.assay_patch.get("lead_organization_study_id")
+        if not trial_id:
+            # We should never hit this, since metadata should be pre-validated.
+            message = "Invalid assay metadata: missing protocol identifier (trial id)."
+            job.status = AssayUploadStatus.MERGE_FAILED.value
+            job.status_details = message
+            session.commit()
             raise Exception(
                 "Invalid metadata: cannot find study ID in metadata. Aborting ingestion."
             )
-        trial_id = job.assay_patch[trial_id_field]
 
         url_mapping = {}
         metadata_with_urls = job.assay_patch
@@ -36,15 +66,16 @@ def ingest_upload(event: dict, context: BackgroundContext):
             url_mapping[upload_url] = target_url
 
             # Copy the uploaded GCS object to the data bucket
-            metadata_with_urls, artifact_metadata = _copy_gcs_object_and_update_metadata(
-                metadata_with_urls,
-                job.assay_type,
-                uuid,
-                GOOGLE_UPLOAD_BUCKET,
-                upload_url,
-                GOOGLE_DATA_BUCKET,
-                target_url,
-            )
+            with saved_failure_status(job, session):
+                destination_object = _gcs_copy(
+                    GOOGLE_UPLOAD_BUCKET, upload_url, GOOGLE_DATA_BUCKET, target_url
+                )
+
+            # Add the artifact info to the metadata patch
+            with saved_failure_status(job, session):
+                metadata_with_urls, artifact_metadata = _add_artifact_to_metadata(
+                    metadata_with_urls, job.assay_type, uuid, destination_object
+                )
 
             # Hang on to the artifact metadata
             print(f"artifact metadata: {artifact_metadata}")
@@ -55,19 +86,22 @@ def ingest_upload(event: dict, context: BackgroundContext):
             "Merging metadata from upload %d into trial %s: " % (job.id, trial_id),
             metadata_with_urls,
         )
-        TrialMetadata.patch_assays(trial_id, metadata_with_urls, session=session)
+        with saved_failure_status(job, session):
+            TrialMetadata.patch_assays(trial_id, metadata_with_urls, session=session)
 
         # Save downloadable files to the database
         # NOTE: this needs to happen after TrialMetadata.patch_assays
         # in order to avoid violating a foreign-key constraint on the trial_id
         # in the event that this is the first upload for a trial.
         for artifact_metadata in downloadable_files:
-            print(
-                f"Saving metadata for {target_url} to downloadable_files table: {artifact_metadata}"
-            )
-            DownloadableFiles.create_from_metadata(
-                trial_id, job.assay_type, artifact_metadata, session=session
-            )
+            print(f"Saving metadata to downloadable_files table: {artifact_metadata}")
+            with saved_failure_status(job, session):
+                DownloadableFiles.create_from_metadata(
+                    trial_id, job.assay_type, artifact_metadata, session=session
+                )
+
+    # Save the upload success
+    job.status = AssayUploadStatus.MERGE_COMPLETED.value
 
     # Google won't actually do anything with this response; it's
     # provided for testing purposes only.
@@ -89,22 +123,14 @@ def _gcs_copy(
     return to_object
 
 
-def _copy_gcs_object_and_update_metadata(
-    metadata: dict,
-    assay_type: str,
-    UUID: str,
-    source_bucket: str,
-    source_object: str,
-    target_bucket: str,
-    target_object: str,
+def _add_artifact_to_metadata(
+    metadata: dict, assay_type: str, UUID: str, destination_object: storage.Blob
 ) -> (dict, dict):
     """Copy a GCS object from one bucket to another and add the GCS uri to the provided metadata."""
+    print(f"Adding artifact {destination_object.name} to metadata.")
 
-    to_object = _gcs_copy(source_bucket, source_object, target_bucket, target_object)
-
-    print(f"Adding artifact {to_object.name} to metadata.")
     updated_trial_metadata, artifact_metadata = TrialMetadata.merge_gcs_artifact(
-        metadata, assay_type, UUID, to_object
+        metadata, assay_type, UUID, destination_object
     )
 
     return updated_trial_metadata, artifact_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules>=0.4.12,<0.5.0
+cidc-api-modules~=0.5.0


### PR DESCRIPTION
Changes related to https://github.com/CIMAC-CIDC/cidc-api-gae/pull/95.

On `ingest_upload` success/failure, update the corresponding upload job's `status` and `status_details` fields appropriately.

Note: this is going to fail to build until `cidc-api-modules==0.5.0` is actually deployed once https://github.com/CIMAC-CIDC/cidc-api-gae/pull/95 is merged.