### PR TITLE
Downloadable assay metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-storage==1.16.1
 psycopg2-binary==2.8.3
 sendgrid==6.0.5
 # The cidc_api_modules package
-cidc-api-modules~=0.5.0
+cidc-api-modules~=0.5.1


### PR DESCRIPTION
Update the `ingest_uploads` cloud function to make assay metadata files downloadable.

Note: build will fail until https://github.com/CIMAC-CIDC/cidc-api-gae/pull/97 is deployed.