### PR TITLE
Load blob metadata from GCS

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -140,7 +140,7 @@ def _get_bucket_and_blob(
     """Get GCS metadata for a storage bucket and blob"""
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(bucket_name)
-    blob = bucket.blob(object_name) if object_name else None
+    blob = bucket.get_blob(object_name) if object_name else None
     return bucket, blob
 
 


### PR DESCRIPTION
Turns out you need to use the `get_blob` method to actually load object metadata like file size.

This is leading to null-related errors from SQLAlchemy when `DownloadableFiles.create_from_blob` is called.