### PR TITLE
Send email alert on assay upload success

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,5 @@ GOOGLE_SECRETS_BUCKET='cidc-secrets-staging'
 
 AUTH0_DOMAIN='https://cidc-test.auth0.com'
 AUTH0_CLIENT_ID='Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD'
+
+ENV="dev"

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -115,7 +115,7 @@ def ingest_upload(event: dict, context: BackgroundContext):
             )
 
         # Save the upload success and trigger email alert
-        job.ingestion_success(session)
+        job.ingestion_success(session=session, send_email=True)
         session.commit()
 
     # Google won't actually do anything with this response; it's

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -114,8 +114,8 @@ def ingest_upload(event: dict, context: BackgroundContext):
                 trial_id, job.assay_type, "Assay Metadata", xlsx_blob, session=session
             )
 
-        # Save the upload success
-        job.status = AssayUploadStatus.MERGE_COMPLETED.value
+        # Save the upload success and trigger email alert
+        job.ingestion_success(session)
         session.commit()
 
     # Google won't actually do anything with this response; it's

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ psycopg2-binary==2.8.3
 sendgrid==6.0.5
 requests==2.22.0
 # The cidc_api_modules package
-cidc-api-modules~=0.9.3
+cidc-api-modules~=0.9.4


### PR DESCRIPTION
Use the interface defined in https://github.com/CIMAC-CIDC/cidc-api-gae/pull/161 to send an email when assay ingestion succeeds.