### PR TITLE
Save metadata patch with artifact info to assay upload job

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -117,9 +117,11 @@ def ingest_upload(event: dict, context: BackgroundContext):
                 trial_id, job.assay_type, "Assay Metadata", xlsx_blob, session=session
             )
 
-        # Save the upload success and trigger email alert
-        job.ingestion_success(session=session, send_email=True)
-        session.commit()
+        # Update the job metadata to include artifacts
+        job.assay_patch = metadata_with_urls
+
+        # Save the upload success and trigger email alert if transaction succeeds
+        job.ingestion_success(session=session, send_email=True, commit=True)
 
     # Google won't actually do anything with this response; it's
     # provided for testing purposes only.


### PR DESCRIPTION
Now, `assay_uploads.assay_patch` will represent the full patch that is actually applied to the corresponding `trial_metadata` object. Currently `assay_uploads.assay_patch` only contains upload placeholder UUIDs for the artifacts.