### PR TITLE
Prevent ingest_upload timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
     - GCLOUD_PROJECT_ID_PROD=cidc-dfci
   matrix:
-    - FUNCTION=ingest_upload TOPIC=uploads TIMEOUT=120 MEMORY=512
+    - FUNCTION=ingest_upload TOPIC=uploads TIMEOUT=600 MEMORY=512
     - FUNCTION=send_email TOPIC=emails TIMEOUT=60 MEMORY=256
     - FUNCTION=generate_csvs TOPIC=patient_sample_update TIMEOUT=60 MEMORY=256
     - FUNCTION=store_auth0_logs TOPIC=daily_cron TIMEOUT=60 MEMORY=256

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ env:
     - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
     - GCLOUD_PROJECT_ID_PROD=cidc-dfci
   matrix:
-    - FUNCTION=ingest_upload TOPIC=uploads
-    - FUNCTION=send_email TOPIC=emails
-    - FUNCTION=generate_csvs TOPIC=patient_sample_update
-    - FUNCTION=store_auth0_logs TOPIC=daily_cron
-    - FUNCTION=vis_preprocessing TOPIC=artifact_upload
+    - FUNCTION=ingest_upload TOPIC=uploads TIMEOUT=120 MEMORY=512
+    - FUNCTION=send_email TOPIC=emails TIMEOUT=60 MEMORY=256
+    - FUNCTION=generate_csvs TOPIC=patient_sample_update TIMEOUT=60 MEMORY=256
+    - FUNCTION=store_auth0_logs TOPIC=daily_cron TIMEOUT=60 MEMORY=256
+    - FUNCTION=vis_preprocessing TOPIC=artifact_upload TIMEOUT=120 MEMORY=512
 before_install:
   # Install and configure the gcloud SDK. Values for these environment
   # variables must be set in the Travis CI console for this to work:
@@ -54,10 +54,10 @@ script:
 
 deploy:
   - provider: script
-    script: bash deploy/pubsub.sh $FUNCTION $TOPIC .env.staging.yaml
+    script: bash deploy/pubsub.sh $FUNCTION $TOPIC .env.staging.yaml $TIMEOUT $MEMORY
     on:
       branch: master
   - provider: script
-    script: bash deploy/pubsub.sh $FUNCTION $TOPIC .env.prod.yaml
+    script: bash deploy/pubsub.sh $FUNCTION $TOPIC .env.prod.yaml $TIMEOUT $MEMORY
     on:
       branch: production

--- a/deploy/pubsub.sh
+++ b/deploy/pubsub.sh
@@ -4,10 +4,14 @@
 ENTRYPOINT=$1
 TOPIC=$2
 ENVFILE=$3
+TIMEOUT=$4
+MEMORY=$5
 PROJECT=$(gcloud config get-value project)
 
 gcloud functions deploy $ENTRYPOINT \
     --runtime python37 \
     --trigger-topic $TOPIC \
     --env-vars-file $ENVFILE \
-    --project $PROJECT
+    --project $PROJECT \
+    --timeout $TIMEOUT \
+    --memory $MEMORY

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -96,6 +96,9 @@ def test_ingest_upload(capsys, monkeypatch):
     _save_blob_file = MagicMock()
     monkeypatch.setattr(DownloadableFiles, "create_from_blob", _save_blob_file)
 
+    _get_by_object_url = MagicMock()
+    monkeypatch.setattr(DownloadableFiles, "get_by_object_url", _get_by_object_url)
+
     _merge_metadata = MagicMock()
     monkeypatch.setattr(TrialMetadata, "patch_assays", _merge_metadata)
 
@@ -127,6 +130,7 @@ def test_ingest_upload(capsys, monkeypatch):
     # Check that the job status was updated to reflect a successful upload
     assert job.status == AssayUploadStatus.MERGE_COMPLETED.value
     assert email_was_sent(capsys.readouterr()[0])
+    _get_by_object_url.assert_called()
     publish_artifact_upload.assert_called()
 
 

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -96,9 +96,6 @@ def test_ingest_upload(capsys, monkeypatch):
     _save_blob_file = MagicMock()
     monkeypatch.setattr(DownloadableFiles, "create_from_blob", _save_blob_file)
 
-    _get_by_object_url = MagicMock()
-    monkeypatch.setattr(DownloadableFiles, "get_by_object_url", _get_by_object_url)
-
     _merge_metadata = MagicMock()
     monkeypatch.setattr(TrialMetadata, "patch_assays", _merge_metadata)
 
@@ -130,7 +127,6 @@ def test_ingest_upload(capsys, monkeypatch):
     # Check that the job status was updated to reflect a successful upload
     assert job.status == AssayUploadStatus.MERGE_COMPLETED.value
     assert email_was_sent(capsys.readouterr()[0])
-    _get_by_object_url.assert_called()
     publish_artifact_upload.assert_called()
 
 


### PR DESCRIPTION
This PR aims to do so in two ways:
* by increasing the allowed runtime of the `ingest_upload` cloud function to 2 minutes (and the memory limit to 512MB)
* by parallelizing the GCS blob copy step of the function