### PR TITLE
Auth0 rate limiting, stackdriver batching, and date-handling fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     - FUNCTION=ingest_upload TOPIC=uploads TIMEOUT=540 MEMORY=512
     - FUNCTION=send_email TOPIC=emails TIMEOUT=60 MEMORY=256
-    - FUNCTION=store_auth0_logs TOPIC=daily_cron TIMEOUT=60 MEMORY=256
+    - FUNCTION=store_auth0_logs TOPIC=daily_cron TIMEOUT=120 MEMORY=256
     - FUNCTION=vis_preprocessing TOPIC=artifact_upload TIMEOUT=120 MEMORY=512
     - FUNCTION=derive_files_from_manifest_upload TOPIC=patient_sample_update TIMEOUT=60 MEMORY=256
     - FUNCTION=derive_files_from_assay_or_analysis_upload TOPIC=assay_or_analysis_upload_complete TIMEOUT=60 MEMORY=1024


### PR DESCRIPTION
This PR fixes a couple issues with the existing Auth0 log ingestion cloud function by:
* making the function adhere to the Auth0 free tier rate limit of 2 requests per second
* batching the write to stackdriver rather than writing line-by-line (this was causing timeouts occasionally)
* naming the GCS objects to which logs are saved based on the dates in the logs themselves, not the date on which the function is run