### PR TITLE
Add missing ENV environment variable to staging and prod configs

### DIFF
--- a/.env.prod.yaml
+++ b/.env.prod.yaml
@@ -1,3 +1,4 @@
+ENV: "prod"
 AUTH0_DOMAIN: "https://cidc.auth0.com"
 AUTH0_CLIENT_ID: "nI74q5VDJ2w2OaKgoK3lAkuxWvCkKP30"
 CLOUD_SQL_INSTANCE_NAME: "cidc-dfci:us-east1:cidc-postgresql-prod"
@@ -10,5 +11,5 @@ GOOGLE_LOGS_BUCKET: "cidc-logs-export-prod"
 GOOGLE_EMAILS_TOPIC: "emails"
 GOOGLE_CLOUD_PROJECT: "cidc-dfci"
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: "{\"wes\":\"cidc-dfci-biofx-wes@ds.dfci.harvard.edu\", \"rna\":\"cidc-dfci-biofx-rna@ds.dfci.harvard.edu\"}"
+GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"

--- a/.env.staging.yaml
+++ b/.env.staging.yaml
@@ -1,3 +1,4 @@
+ENV: "staging"
 AUTH0_DOMAIN: "https://cidc-test.auth0.com"
 AUTH0_CLIENT_ID: "Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD"
 CLOUD_SQL_INSTANCE_NAME: "cidc-dfci-staging:us-central1:cidc-postgresql-staging"
@@ -9,6 +10,6 @@ GOOGLE_DATA_BUCKET: "cidc-data-staging"
 GOOGLE_LOGS_BUCKET: "cidc-logs-export-staging"
 GOOGLE_EMAILS_TOPIC: "emails"
 GOOGLE_CLOUD_PROJECT: "cidc-dfci-staging"
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: "{\"wes\":\"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu\", \"rna\":\"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu\"}"
+GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"


### PR DESCRIPTION
This fixes the bug that caused us to get emails saying data was uploaded to staging when it was actually uploaded to prod. We weren't setting `ENV` appropriately in cloud functions, and `cidc_api.config.settings.ENV` defaults to `"staging"` (we don't actually want this default, so up next will be a PR removing that default from the API here https://github.com/CIMAC-CIDC/cidc-api-gae/blob/b24b388d1c4224d87fdb9576dec550d4bde3527b/cidc_api/config/settings.py#L15).