### PR TITLE
Fix create_from_blob kwarg typo in _derive_files_from_upload

### DIFF
--- a/functions/upload_postprocessing.py
+++ b/functions/upload_postprocessing.py
@@ -90,7 +90,7 @@ def _derive_files_from_upload(trial_id: str, upload_type: str, session):
             artifact.data_format,
             blob,
             session=session,
-            publish_artifact_upload=True,
+            alert_artifact_upload=True,
         )
         df_record.additional_metadata = artifact.metadata
         # Assume that a derived file will be directly useful for data analysis


### PR DESCRIPTION
This was preventing all derivative files from getting published (e.g., participant and sample CSVs after manifest upload).