### PR TITLE
Add disable_inactive_users function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - FUNCTION=ingest_upload TOPIC=uploads TIMEOUT=540 MEMORY=1024
     - FUNCTION=send_email TOPIC=emails TIMEOUT=60 MEMORY=256
     - FUNCTION=store_auth0_logs TOPIC=daily_cron TIMEOUT=120 MEMORY=256
+    - FUNCTION=disable_inactive_users TOPIC=daily_cron TIMEOUT=120 MEMORY=256
     - FUNCTION=vis_preprocessing TOPIC=artifact_upload TIMEOUT=120 MEMORY=512
     - FUNCTION=derive_files_from_manifest_upload TOPIC=patient_sample_update TIMEOUT=60 MEMORY=256
     - FUNCTION=derive_files_from_assay_or_analysis_upload TOPIC=assay_or_analysis_upload_complete TIMEOUT=60 MEMORY=1024

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Google Cloud Functions for carrying out event-driven tasks in the CIDC.
   - `derive_files_from_assay_or_analysis_upload`: when an assay or analysis upload completes, generate derivative files for the associated trial.
   - `store_auth0_logs`: pull logs for the past day from Auth0 and store them in Google Cloud Storage.
   - `send_email`: when an email is published to the "emails" topic, sends the email using the SendGrid API.
+  - `disable_inactive_users`: find users who appear to have become inactive, and disable their accounts.
 
 ## Development
 

--- a/functions/users.py
+++ b/functions/users.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Query
+from cidc_api.models import Users
+
+from .util import sqlalchemy_session
+
+
+def disable_inactive_users(*args):
+    """Disable any users who haven't logged in for `INACTIVE_DAY_THRESHOLD` days."""
+    with sqlalchemy_session() as session:
+        print("Disabling inactive users...")
+        Users.disable_inactive_users(session=True)
+        print("done.")

--- a/functions/users.py
+++ b/functions/users.py
@@ -7,7 +7,7 @@ from .util import sqlalchemy_session
 
 
 def disable_inactive_users(*args):
-    """Disable any users who haven't logged in for `INACTIVE_DAY_THRESHOLD` days."""
+    """Disable any users who have become inactive."""
     with sqlalchemy_session() as session:
         print("Disabling inactive users...")
         Users.disable_inactive_users(session=True)

--- a/functions/users.py
+++ b/functions/users.py
@@ -10,5 +10,5 @@ def disable_inactive_users(*args):
     """Disable any users who have become inactive."""
     with sqlalchemy_session() as session:
         print("Disabling inactive users...")
-        Users.disable_inactive_users(session=True)
+        Users.disable_inactive_users(session=session)
         print("done.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ clustergrammer==1.13.6
 scikit-learn==0.21.3 # clustergrammer dependency
 
 # The cidc_api_modules package
-cidc-api-modules~=0.18.2
+cidc-api-modules~=0.18.4

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -1,0 +1,14 @@
+from unittest.mock import MagicMock
+
+from functions import users
+
+
+def test_disable_inactive_users(monkeypatch):
+    """Smoketest for the disable_inactive users function"""
+    monkeypatch.setattr("functions.util.sqlalchemy_session", MagicMock())
+    Users = MagicMock()
+    Users.disable_inactive_users = MagicMock()
+    monkeypatch.setattr(users, "Users", Users)
+
+    users.disable_inactive_users()
+    Users.disable_inactive_users.assert_called()


### PR DESCRIPTION
Accompaniment for https://github.com/CIMAC-CIDC/cidc-api-gae/pull/249

Adds the `disable_inactive_users` function, triggered by the `daily_cron` pubsub topic.