### PR TITLE
Share one GCS client; introduce more multithreading

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,16 @@
 # Environment variable configs for local testing
-POSTGRES_URI='postgresql://cidcdev:1234@localhost:5432/cidc'
 TEST_POSTGRES_URI='postgresql://cidcdev:1234@localhost:5432/cidctest'
+
+
+# Connect to a local postgres instance
+POSTGRES_URI='postgresql://cidcdev:1234@localhost:5432/cidc'
+
+# Connect to our Cloud SQL Postgres instance.
+# Note: POSTGRES_URI must be commented out for this to work
+# CLOUD_SQL_SOCKET_DIR='<YOUR HOME DIRECTORY>/.cloudsql/'
+# CLOUD_SQL_INSTANCE_NAME='cidc-dfci-staging:us-central1:cidc-postgresql-staging'
+# CLOUD_SQL_DB_USER='cidcuser'
+# CLOUD_SQL_DB_NAME='cidc-staging'
 
 DEV_CFUNCTIONS_SERVER='http://localhost:3001'
 GCP_PROJECT='cidc-dfci-staging'


### PR DESCRIPTION
This PR improves the `ingest_upload` function in two ways:
* decreases memory requirements by sharing one GCS client across calls to cloud storage, rather than instantiating a new client for every GCS operation.
* improves performance by taking advantage of a couple additional opportunities for multithreading on IO-bound operations.

Some initial experimentation suggests that all of the `print` statements in the `ingest_upload` function may also be slowing it down, so I'm going to leave this PR as a draft while I consider alternatives. The biggest performance hit we take is on artifact metadata merging, though, which is a product of inefficiency in `prism`'s implementation.

