### PR TITLE
Remove global GCS storage client from uploads.py

### DIFF
--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -82,7 +82,7 @@ def test_ingest_upload(caplog, monkeypatch):
 
     # Mock data transfer functionality
     _gcs_copy = MagicMock()
-    _gcs_copy.side_effect = lambda source_bucket, source_object, target_bucket, target_object: _gcs_obj_mock(
+    _gcs_copy.side_effect = lambda storage_client, source_bucket, source_object, target_bucket, target_object: _gcs_obj_mock(
         target_object,
         100,
         datetime.datetime.now(),
@@ -149,7 +149,9 @@ def test_ingest_upload(caplog, monkeypatch):
     # Check that we tried to merge metadata once
     _merge_metadata.assert_called_once()
     # Check that we got the xlsx blob metadata from GCS
-    _get_bucket_and_blob.assert_called_with(GOOGLE_DATA_BUCKET, job.gcs_xlsx_uri)
+    _get_bucket_and_blob.assert_called_with(
+        _storage_client, GOOGLE_DATA_BUCKET, job.gcs_xlsx_uri
+    )
     # Check that we created a downloadable file for the xlsx file blob
     assert _save_blob_file.call_args[:-1][0] == (
         "CIMAC-12345",


### PR DESCRIPTION
This should at least remove any doubt as to whether shared `storage.Client` instances are the source of our Google auth errors, and at best actually fix the auth errors.