### PR TITLE
Prevent duplicate biofx analysis group iam bindings

### DIFF
--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -262,7 +262,7 @@ def _gcs_add_prefix_reader_permission(group_email: str, prefix: str):
     matching_binding_index = None
     for i, binding in enumerate(policy.bindings):
         role_matches = binding.get("role") == GOOGLE_ANALYSIS_GROUP_ROLE
-        member_matches = binding.get("members") == {group_member}
+        member_matches = group_member in binding.get("members", {})
         prefix_matches = prefix_check in binding.get("condition", {}).get(
             "expression", ""
         )
@@ -284,7 +284,7 @@ def _gcs_add_prefix_reader_permission(group_email: str, prefix: str):
     policy.bindings.append(
         {
             "role": GOOGLE_ANALYSIS_GROUP_ROLE,
-            "members": [group_member],
+            "members": {group_member},
             "condition": {
                 "title": f"Biofx {prefix} until {grant_until_date}",
                 "description": f"Auto-assigned from cidc-cloud-functions/uploads on {datetime.now()}",

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -1,6 +1,7 @@
 """A pub/sub triggered functions that respond to data upload events"""
 import sys
 import logging
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Optional, Tuple, NamedTuple
@@ -253,18 +254,41 @@ def _gcs_add_prefix_reader_permission(group_email: str, prefix: str):
         .isoformat()
     )
 
-    prefixCheck = f'resource.name.startsWith("projects/_/buckets/{GOOGLE_DATA_BUCKET}/objects/{cleaned_prefix}/")'
-    expiryCheck = f'request.time < timestamp("{grant_until_date}T00:00:00Z")'
+    prefix_check = f'resource.name.startsWith("projects/_/buckets/{GOOGLE_DATA_BUCKET}/objects/{cleaned_prefix}/")'
+    expiry_check = f'request.time < timestamp("{grant_until_date}T00:00:00Z")'
+    group_member = f"group:{group_email}"
+
+    # look for a duplicate conditional binding
+    matching_binding_index = None
+    for i, binding in enumerate(policy.bindings):
+        role_matches = binding.get("role") == GOOGLE_ANALYSIS_GROUP_ROLE
+        member_matches = binding.get("members") == {group_member}
+        prefix_matches = prefix_check in binding.get("condition", {}).get(
+            "expression", ""
+        )
+        if role_matches and member_matches and prefix_matches:
+            # we shouldn't have multiple bindings matching these conditions
+            if matching_binding_index is not None:
+                warnings.warn(
+                    f"Found multiple conditional bindings for {group_email} on {prefix}. This is an invariant violation - "
+                    "check out permissions on the CIDC GCS buckets to debug."
+                )
+                break
+            matching_binding_index = i
+
+    # if one exists, delete it so we can replace it below
+    if matching_binding_index is not None:
+        policy.bindings.pop(matching_binding_index)
 
     # following https://github.com/GoogleCloudPlatform/python-docs-samples/pull/2730/files
     policy.bindings.append(
         {
             "role": GOOGLE_ANALYSIS_GROUP_ROLE,
-            "members": ["group:" + group_email],
+            "members": [group_member],
             "condition": {
                 "title": f"Biofx {prefix} until {grant_until_date}",
                 "description": f"Auto-assigned from cidc-cloud-functions/uploads on {datetime.now()}",
-                "expression": f"{prefixCheck} && {expiryCheck}",
+                "expression": f"{prefix_check} && {expiry_check}",
             },
         }
     )

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -172,7 +172,7 @@ def test_ingest_upload(caplog, monkeypatch):
     # Check that we aded GCS access for biofx team
     assert _policy == _set_iam_policy.call_args[0][0]
     assert len(_policy.bindings) == 1
-    assert _policy.bindings[0]["members"] == ["group:analysis-group@email"]
+    assert _policy.bindings[0]["members"] == {"group:analysis-group@email"}
     assert _policy.bindings[0]["role"] == "projects/cidc-dfci-staging/roles/CIDC_biofx"
     assert iam_prefix in _policy.bindings[0]["condition"]["expression"]
     _until = datetime.datetime.today() + datetime.timedelta(


### PR DESCRIPTION
Fixes a bug where many duplicate conditional IAM bindings were created for the same GCS prefix. The code is more or less copied from `cidc_api.shared.gcloud_client` (https://github.com/CIMAC-CIDC/cidc-api-gae/blob/5701210f10e77583c2bebe840e10a2d0d8ff51d2/cidc_api/shared/gcloud_client.py#L339), but slight differences for this use case would've required modifying the `gcloud_client` code. Preventing interdependency seemed like the lesser of two evils.