### PR TITLE
CIDC-1130 api/schemas bump for TCRseq controls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ statsmodels==0.12.2
 scikit_learn==0.24.2
 
 # The cidc_api_modules package
-cidc-api-modules~=0.24.51
+cidc-api-modules~=0.25.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ statsmodels==0.12.2
 scikit_learn==0.24.2
 
 # The cidc_api_modules package
-cidc-api-modules~=0.25.10
+cidc-api-modules~=0.25.11


### PR DESCRIPTION
## What & Why

Adds a controls section for TCRseq assay, as well as a sheet on tcr_adaptive assay template as well.  
Extends [CIDC-1130](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1130) because I missed this last time.  
See https://github.com/CIMAC-CIDC/cidc-schemas/pull/500 and https://github.com/CIMAC-CIDC/cidc-api-gae/pull/577

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
