### PR TITLE
CIDC-1134 update CSMS event data format to use dict

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ topics_to_functions = {
     "artifact_upload": vis_preprocessing,
     "patient_sample_update": derive_files_from_manifest_upload,
     "assay_or_analysis_upload": derive_files_from_assay_or_analysis_upload,
+    "csms_trigger": update_cidc_from_csms,
     "daily_cron": [
         store_auth0_logs,
         disable_inactive_users,

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -65,7 +65,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
 
     # if matches on the trial_id, only changes those
     mock_detect.return_value = ({}, [])  # records, changes
-    match_trial_event = make_pubsub_event(f"trial_id=foo&manifest_id=*")
+    match_trial_event = make_pubsub_event(str({"trial_id": "foo", "manifest_id": "*"}))
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 2
@@ -95,7 +95,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     reset()
     # if matches on the manifest_id, only changes that one
     # manifest_id is asserted to be unique in the CIDC database
-    match_trial_event = make_pubsub_event(f"trial_id=*&manifest_id=baz")
+    match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "baz"}))
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -124,7 +124,9 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     reset()
     # if matches on the trial_id and manifest_id, only changes that one
     mock_detect.return_value = ({}, [])  # records, changes
-    match_trial_event = make_pubsub_event(f"trial_id=foo&manifest_id=bar")
+    match_trial_event = make_pubsub_event(
+        str({"trial_id": "foo", "manifest_id": "bar"})
+    )
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -153,7 +155,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     reset()
     # if matches none, does nothing
     mock_detect.return_value = ({}, [])  # records, changes
-    match_trial_event = make_pubsub_event(f"trial_id=*&manifest_id=foo")
+    match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "foo"}))
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json, mock_email]:
         assert mock.call_count == 0
@@ -195,7 +197,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
 
     # if bad-key but correctly formatted event data, error directly
     mock_detect.side_effect = Exception("foo")
-    bad_event = make_pubsub_event("key=value")
+    bad_event = make_pubsub_event(str({"key": "value"}))
     with pytest.raises(
         Exception, match="Both trial_id and manifest_id matching must be provided"
     ):
@@ -236,7 +238,7 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
     mock_detect = MagicMock()
     monkeypatch.setattr(functions.csms, "detect_manifest_changes", mock_detect)
 
-    match_all_event = make_pubsub_event("trial_id=*&manifest_id=*")
+    match_all_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "*"}))
 
     def reset():
         for mock in [


### PR DESCRIPTION
## What

Update event data format to use stringified python dict for matching the trial and manifest IDs when doing CSMS change detection.

## Why

Discovered in testing. Old implementation used url-style param strings but did not include the required character escaping and so failed when the manifest ID contains an `&`, which is quite common in eg H&E.

## How

Instead, this uses the result of `str` of a python `dict` containing the values which is then reparsed via `dict(eval(<data>))` within the function to regenerate the exact input.

## Remarks

* Any failures in unpacking continue to do a dry-run against all manifests (with a warning)
* Correctly unpacked data that doesn't contain both trial and manifest ID continue to throw an Exception
* Despite the usual concerns around using `eval`, this is believed to be safe here as it immediately cast to a `dict` and validated for the only keys that are accessed. The values are then only used in `not in (<test str>, "*")`-derived equivalence tests to see if a manifest should be skipped or not.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)