### PR TITLE
CIDC-1134 skip completed manifests that don't have samples

### DIFF
--- a/functions/csms.py
+++ b/functions/csms.py
@@ -76,9 +76,13 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         manifest_iterator: Iterator[Dict[str, Any]] = get_with_paging("/manifests")
 
         for manifest in manifest_iterator:
-            # only test those manifests that are qc_complete
+            # only test those manifests that are qc_complete AND have samples
             # if they're not qc_complete, _extract_info_from_manifest might throw errors from _get_and_check
-            if manifest.get("status") not in ("qc_complete", None):
+            # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
+            if (
+                manifest.get("status") not in ("qc_complete", None)
+                or len(manifest.get("samples", [])) == 0
+            ):
                 continue
 
             # TODO should we remove this matching once we're out of testing?

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -15,23 +15,29 @@ def test_update_cidc_from_csms_status_filtering(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],
     }
     manifest2 = {
         "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
         "status": "qc_complete",
     }
     manifest3 = {
         "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [],
+        "samples": [{}],  # len != 0
         "status": "draft",
+    }
+    manifest4 = {
+        "protocol_identifier": "foo",
+        "manifest_id": "biz",
+        "samples": [],
+        "status": "qc_complete",
     }
 
     mock_api_get = MagicMock()
-    mock_api_get.return_value = [manifest, manifest2, manifest3]
+    mock_api_get.return_value = [manifest, manifest2, manifest3, manifest4]
     mock_extract_info_from_manifest = MagicMock()
     mock_extract_info_from_manifest.return_value = ("trial", "manifest", [])
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
@@ -58,6 +64,10 @@ def test_update_cidc_from_csms_status_filtering(monkeypatch):
         manifest3 not in args
         for args, _ in mock_extract_info_from_manifest.call_args_list
     )
+    assert all(
+        manifest4 not in args
+        for args, _ in mock_extract_info_from_manifest.call_args_list
+    )
 
 
 @with_app_context
@@ -65,17 +75,17 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest2 = {
         "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest3 = {
         "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
 
     mock_api_get = MagicMock()
@@ -259,12 +269,12 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest2 = {
         "protocol_identifier": "foo",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
 
     mock_api_get = MagicMock()


### PR DESCRIPTION
Discovered in testing. Causes error from `_get_and_check(manifest, "samples")` in `_extract_info_from_manifest(manifest)`.
Since it has no samples, there's nothing to sync with CIDC, so it is safe to skip.