### PR TITLE
CIDC-1134 update trial_id matching to _get_and_check from samples

### DIFF
--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -13,32 +13,21 @@ from cidc_api.shared.emails import CIDC_MAILING_LIST
 @with_app_context
 def test_update_cidc_from_csms_matching_some(monkeypatch):
     manifest = {
-        "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
     manifest2 = {
-        "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foobar",}],  # len != 0
     }
     manifest3 = {
-        "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
 
     mock_api_get = MagicMock()
     mock_api_get.return_value = [manifest, manifest2, manifest3]
-    mock_extract_info_from_manifest = lambda m, session: (
-        m["protocol_identifier"],
-        m["manifest_id"],
-        [],
-    )
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
-    monkeypatch.setattr(
-        functions.csms, "_extract_info_from_manifest", mock_extract_info_from_manifest
-    )
 
     mock_insert_json, mock_insert_blob = MagicMock(), MagicMock()
     monkeypatch.setattr(functions.csms, "insert_manifest_from_json", mock_insert_json)
@@ -69,10 +58,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     match_trial_event = make_pubsub_event(str({"trial_id": "foo", "manifest_id": "*"}))
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "trial_id=foo" in args[0] and "manifest_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id" not in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 2
@@ -106,10 +92,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "baz"}))
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "manifest_id=baz" in args[0] and "trial_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=baz" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -144,10 +127,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     )
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "trial_id=foo" in args[0] and "manifest_id=bar" in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=bar" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -179,10 +159,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     mock_api_get.return_value = []
     match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "foo"}))
     assert all(
-        [
-            "manifest_id=foo" in args[0] and "trial_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=foo" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json, mock_email]:
@@ -194,17 +171,14 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     mock_api_get.return_value = [manifest, manifest2, manifest3]
     update_cidc_from_csms({}, None)
     assert all(
-        [
-            "trial_id" not in args[0] and "manifest_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id" not in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 0
     mock_logger.warning.assert_called_once()
     args, _ = mock_logger.warning.call_args_list[0]
     assert (
-        "Both trial_id and manifest_id matching must be provided, no actual data changes will be made."
+        "manifest_id matching must be provided, no actual data changes will be made."
         in args[0]
     )
 
@@ -214,7 +188,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        "Both trial_id and manifest_id matching must be provided, no actual data changes will be made."
+        "manifest_id matching must be provided, no actual data changes will be made."
         in args[2]
     )
     assert (
@@ -233,36 +207,24 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     # if bad-key but correctly formatted event data, error directly
     mock_detect.side_effect = Exception("foo")
     bad_event = make_pubsub_event(str({"key": "value"}))
-    with pytest.raises(
-        Exception, match="Both trial_id and manifest_id matching must be provided"
-    ):
+    with pytest.raises(Exception, match="manifest_id matching must be provided"):
         update_cidc_from_csms(bad_event, None)
 
 
 @with_app_context
 def test_update_cidc_from_csms_matching_all(monkeypatch):
     manifest = {
-        "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
     manifest2 = {
-        "protocol_identifier": "foo",
         "manifest_id": "baz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
 
     mock_api_get = MagicMock()
     mock_api_get.return_value = [manifest, manifest2]
-    mock_extract_info_from_manifest = lambda m, session: (
-        m["protocol_identifier"],
-        m["manifest_id"],
-        [],
-    )
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
-    monkeypatch.setattr(
-        functions.csms, "_extract_info_from_manifest", mock_extract_info_from_manifest
-    )
 
     mock_insert_json, mock_insert_blob = MagicMock(), MagicMock()
     monkeypatch.setattr(functions.csms, "insert_manifest_from_json", mock_insert_json)


### PR DESCRIPTION
## What

Update `trial_id` matching to `_get_and_check` from samples.
Also add logging of email just to make sure

## Why

Testing discovered. `protocol_identifier` is not stored at the manifest level in CSMS -- as other users of CSMS will have cross-trial manifests. Confirmed via email with Radim that all `status=qc_complete` manifests for CIMAC / CIDC will have a consistent `protocol_identifier` across all `sample` entries.

## How

Instead of adding `trial_id=<value>`  to url params for CSMS call, use API's `_get_and_check` as used elsewhere in CIDC to get the `protocol_identifier`s from the samples and assert that the value is consistent across all samples.
Then do `trial_id` matching based on this retrieved value.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
