### PR TITLE
CIDC-1134 better logging of errors

### DIFF
--- a/functions/csms.py
+++ b/functions/csms.py
@@ -90,7 +90,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
             trial_id = _get_and_check(
                 obj=samples,
                 key="protocol_identifier",
-                msg=f"No consistent protocol_identifier defined for samples on manifest {data['manifest_id']}",
+                msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
             )
             # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
             if len(samples) == 0:
@@ -135,15 +135,14 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
 
             except Exception as e:
                 logger.error(
-                    f"Error from {e.___traceback__.tb_frame if e.__traceback__ else None}: {e!r}"
+                    f"Error from {e.__traceback__.tb_frame if hasattr(e, '__traceback__') and e.__traceback__ else None}: {e!r}"
                 )
                 email_msg.append(
                     f"Problem with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}",
                 )
-            finally:
-                logger.info(f"Email: {email_msg}")
 
         if email_msg:
+            logger.info(f"Email: {email_msg}")
             send_email(
                 CIDC_MAILING_LIST,
                 f"Summary of Update from CSMS: {datetime.now()}",

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -73,15 +73,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
         in args[2]
     )
 
@@ -106,15 +106,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')}"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
         not in args[2]
     )
 
@@ -141,15 +141,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
         not in args[2]
     )
 
@@ -192,15 +192,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         in args[2]
     )
     assert (
-        f"Would add new {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"Would add new {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"Would add new {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"Would add new {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"Would add new {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
+        f"Would add new {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
         in args[2]
     )
 
@@ -282,11 +282,11 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
 
@@ -301,11 +301,11 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"Problem with {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')}: {Exception('foo')!s}"
+        f"Problem with {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')}: {Exception('foo')!r}"
         in args[2]
     )
     assert (
-        f"Problem with {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}: {Exception('foo')!s}"
+        f"Problem with {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}: {Exception('foo')!r}"
         in args[2]
     )
     for mock in [


### PR DESCRIPTION
## What & Why

In testing, discovered that `str(error)` isn't that useful compared to `repr(error)`. Additionally, added direct logging including a reference to where in the code threw the error.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
