### PR TITLE
CIDC-1134 catch any _get_and_check errors and skip

### DIFF
--- a/functions/csms.py
+++ b/functions/csms.py
@@ -87,16 +87,18 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         for manifest in manifest_iterator:
             # TODO should we remove this matching once we're out of testing?
             samples = manifest.get("samples", [])
-            trial_id = _get_and_check(
-                obj=samples,
-                key="protocol_identifier",
-                msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
-            )
-            # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
-            if len(samples) == 0:
+            try:
+                trial_id = _get_and_check(
+                    obj=samples,
+                    key="protocol_identifier",
+                    msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
+                )
+            except:
+                # if it doesn't have a consistent protocol_identifier, just skip it
                 continue
+
             # trial_id matching has to be done via _get_and_check as it is only stored on the samples
-            elif (
+            if (
                 "trial_id" in data
                 and data["trial_id"] != "*"
                 and trial_id != data["trial_id"]


### PR DESCRIPTION
## What & Why

Discovered in testing, catch any `_get_and_check` errors and skip -- namely when there are no samples or no `trial_id`.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
