### PR TITLE
CIDC-1135 add secret to pass to uploader_email

### DIFF
--- a/functions/csms.py
+++ b/functions/csms.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, Dict, Iterator
 from urllib.parse import quote as url_escape
 
-from .settings import ENV
+from .settings import ENV, INTERNAL_USER_EMAIL
 from .util import (
     BackgroundContext,
     extract_pubsub_data,
@@ -25,8 +25,6 @@ from cidc_api.shared.emails import CIDC_MAILING_LIST
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
-
-UPLOADER_EMAIL = ""
 
 
 def update_cidc_from_csms(event: dict, context: BackgroundContext):
@@ -110,7 +108,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 # # using a different function, so we don't need to catch a change on any other manifest
                 # throws an error if any change to critical functions, so we do need catch those
                 _ = detect_manifest_changes(
-                    manifest, uploader_email=UPLOADER_EMAIL, session=session
+                    manifest, INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL, session=session
                 )
                 # with updates within API's detect_manifest_changes() itself, we can capture
                 # # these changes and insert new manifests here, eliminating NewManifestError altogether
@@ -119,12 +117,16 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 if data:
                     # relational hook
                     insert_manifest_from_json(
-                        manifest, uploader_email=UPLOADER_EMAIL, session=session
+                        manifest,
+                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
+                        session=session,
                     )
 
                     # schemas JSON blob hook
                     insert_manifest_into_blob(
-                        manifest, uploader_email=UPLOADER_EMAIL, session=session
+                        manifest,
+                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
+                        session=session,
                     )
 
                     email_msg.append(

--- a/functions/settings.py
+++ b/functions/settings.py
@@ -46,6 +46,9 @@ AUTH0_CLIENT_SECRET = secrets.get("AUTH0_CLIENT_SECRET")
 # SendGrid config
 SENDGRID_API_KEY = secrets.get("SENDGRID_API_KEY")
 
+# Internal User For eg pseudo uploads
+INTERNAL_USER_EMAIL = secrets.get("INTERNAL_USER_EMAIL")
+
 # Check for configuration that must be defined if we're running in GCP
 if GCP_PROJECT:
     assert GOOGLE_DATA_BUCKET is not None

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 from tests.util import make_pubsub_event, with_app_context
 
 import functions.csms
-from functions.csms import UPLOADER_EMAIL, update_cidc_from_csms
+
+# mock the env setting
+functions.csms.INTERNAL_USER_EMAIL = "user@email.com"
+
+from functions.csms import INTERNAL_USER_EMAIL, update_cidc_from_csms
 
 from cidc_api.models.templates.csms_api import NewManifestError
 from cidc_api.shared.emails import CIDC_MAILING_LIST
@@ -65,7 +69,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest3)[i] in args
-            assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -98,7 +102,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest2 in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -133,7 +137,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -254,7 +258,8 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
     for i in range(2):
         args, kwargs = mock_detect.call_args_list[i]
         assert (manifest, manifest2)[i] in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        print(kwargs)
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
 
     for mock in [
@@ -274,7 +279,7 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest2)[i] in args
-            assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]


### PR DESCRIPTION
## What

Add Google secret to pass to uploader_email in CSMS pseudo-upload.

## Why

[CIDC-1135](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1135) causes fk error on `uploader_email=''`

## How

Added to staging secrets and mocked in tests

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
