### PR TITLE
CIDC-1134 catch errors in inserting a new manifest as well

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.42
+cidc-api-modules~=0.25.43


### PR DESCRIPTION
## What

Catch errors in inserting a new manifest as well

## Why

[This testing example](https://console.cloud.google.com/logs/query;query=resource.labels.function_name%3D%22update_cidc_from_csms%22%0Alabels.execution_id%3D%22m1umfjcjeppp%22;timeRange=PT3H;cursorTimestamp=2021-11-19T21:52:47.038Z?project=cidc-dfci-staging) didn't generate an email.

## How

Use nested `try...catch...else` for errors while catching inside `NewManifestError`

## Remarks

Added test to prevent reversion.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
