### PR TITLE
CIDC-1135 use new dry_run variable for better error checking when not actually inserting

### DIFF
--- a/functions/csms.py
+++ b/functions/csms.py
@@ -36,10 +36,12 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
 
     `event` data is base64-encoded str(dict) in the form {"trial_id": "<trial>", "manifest_id": "<manifest>"}
         values for "trial_id" and "manifest_id" are used to see whether a manifest should be processed
-        special keyword "*" matches all
-        special case recasting via dict(eval(<decoded data>)) errors, dry run of all manifests
+        special value "*" matches all
+        fallback case if dict(data) raises error is dry run of all manifests
     NOTE This matching should be reconsidered once all CIDC / CSMS data is aligned and we're out of testing
     """
+    dry_run: bool = True
+
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data
@@ -50,33 +52,40 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         # just dry-run all of the manifest changes
         data: dict = {}
 
+    else:
+        # TODO should we remove this matching once we're out of testing?
+        if "trial_id" not in data or "manifest_id" not in data:
+            raise Exception(
+                f"trial_id and manifest_id matching must both be provided, you provided: {data}"
+            )
+        dry_run = False
+
     email_msg = []
-    # TODO should we remove this matching once we're out of testing?
-    if data and ("manifest_id" not in data):
-        raise Exception(f"manifest_id matching must be provided, you provided: {data}")
 
-    elif not data:
+    if dry_run:
         if "data" in event:
-            event["data"] = extract_pubsub_data(event)
-        logger.warning(
-            f"manifest_id matching must be provided, no actual data changes will be made. Provided: {event!s}"
-        )
+            try:
+                # for human readability, but could be what errored above
+                event["data"] = extract_pubsub_data(event)
+            except Exception:
+                pass
+
+        logger.info(f"Dry-run call to update CIDC from CSMS. Provided: {event!s}")
         email_msg.append(
-            f"manifest_id matching must be provided, no actual data changes will be made. You provided: {event!s}"
+            f"To make changes, trial_id and manifest_id matching must both be provided in the event data. You provided: {event!s}"
         )
 
-    logger.info(
-        f"Call to update CIDC from CSMS matching: {data!s}\nIf {dict()!s}, then dry-run all."
-    )
+    else:
+        logger.info(f"Call to update CIDC from CSMS matching: {data!s}")
 
     with sqlalchemy_session() as session:
         url = "/manifests"
-        # only care about manifests that are qc_complete
+        # only care about manifests that are qc_complete and non-"legacy" ie not excluded
         match_conditions = ["status=qc_complete", "excluded=false"]
 
         # TODO should we remove this matching once we're out of testing?
         # add matching conditions if not matching all
-        if data.get("manifest_id", "*") != "*":
+        if not dry_run and data["manifest_id"] != "*":
             match_conditions.append(f"manifest_id={url_escape(data['manifest_id'])}")
 
         url += "?" + "&".join(match_conditions)
@@ -92,26 +101,22 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                     msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
                 )
             except Exception as e:
-                # if it doesn't have a consistent protocol_identifier, just skip it
+                # if it doesn't have a consistent protocol_identifier, just log the error and skip it
                 logger.error(str(e))
                 continue
 
             # trial_id matching has to be done via _get_and_check as it is only stored on the samples
-            if (
-                "trial_id" in data
-                and data["trial_id"] != "*"
-                and trial_id != data["trial_id"]
-            ):
+            if not dry_run and data["trial_id"] != "*" and trial_id != data["trial_id"]:
                 logger.info(
                     f"Skipping manifest {manifest.get('manifest_id')} from {trial_id} != {data['trial_id']}"
                 )
                 continue
 
             try:
+                # throws an error instead the catch if any change to critical fields, so we do need catch those too
                 try:
-                    # returns list of model instances, but we're only dealing with new manifests
+                    # returns `records`: list of model instances, but we're only dealing with new manifests
                     # # using a different function, so we don't need to catch a change on any other manifest
-                    # throws an error if any change to critical functions, so we do need catch those
                     _, changes = detect_manifest_changes(
                         manifest, uploader_email=INTERNAL_USER_EMAIL, session=session
                     )
@@ -124,6 +129,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         insert_manifest_from_json(
                             manifest,
                             uploader_email=INTERNAL_USER_EMAIL,
+                            dry_run=dry_run,
                             session=session,
                         )
 
@@ -131,6 +137,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         insert_manifest_into_blob(
                             manifest,
                             uploader_email=INTERNAL_USER_EMAIL,
+                            dry_run=dry_run,
                             session=session,
                         )
 
@@ -149,6 +156,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         )
 
                 else:
+                    # TODO in the future, should actually store returned records above and call insert_record_batch(records)
                     logger.info(
                         f"Changes found for {trial_id} manifest {manifest.get('manifest_id')}: {changes}"
                     )

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -42,6 +42,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
     """
     dry_run: bool = True
 
+    # TODO should we remove this matching once we're out of testing?
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data
@@ -53,12 +54,12 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         data: dict = {}
 
     else:
-        # TODO should we remove this matching once we're out of testing?
-        if "trial_id" not in data or "manifest_id" not in data:
-            raise Exception(
-                f"trial_id and manifest_id matching must both be provided, you provided: {data}"
-            )
-        dry_run = False
+        if data:
+            if "trial_id" not in data or "manifest_id" not in data:
+                raise Exception(
+                    f"trial_id and manifest_id matching must both be provided, you provided: {data}"
+                )
+            dry_run = False
 
     email_msg = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.43
+cidc-api-modules~=0.25.44


### PR DESCRIPTION
## What

Use new explicit variable for dry_run for better error checking when not actually inserting, facilitated by https://github.com/CIMAC-CIDC/cidc-api-gae/pull/629 .

## Why

Currently, dry_run of CSMS sync in cloud functions doesn't actually check any of the db values, so mainly errors caught by [models/templates/csms_api.py::_initial_manifest_validation](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/csms-dry_run/cidc_api/models/templates/csms_api.py#L748) were being checked in [models/templates/csms_api.py::detect_manifest_changes](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/csms-dry_run/cidc_api/models/templates/csms_api.py#L954).  
This allows for an explicit check and rollback call from the cloud function to both `insert_manifest_from_json` and `insert_manifest_into_blob`.

## How

- Use default `dry_run = True`, set to `False` only if data passed is valid dict and not `{}`.
- Still raises error if data passed is valid dict without the correct keys.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
