### PR TITLE
Prod deploy for notes in WES paired analysis, CSMS functionality

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,4 @@ Please include and complete the following checklist. You can mark an item as com
 - [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
 - [ ] Docstrings - Docstrings have been provided for functions
 - [ ] Documentation - README has been updated to explain major changes & new features
+- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, Dict, Iterator
 from urllib.parse import quote as url_escape
 
-from .settings import ENV
+from .settings import ENV, INTERNAL_USER_EMAIL
 from .util import (
     BackgroundContext,
     extract_pubsub_data,
@@ -25,8 +25,6 @@ from cidc_api.shared.emails import CIDC_MAILING_LIST
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
-
-UPLOADER_EMAIL = ""
 
 
 def update_cidc_from_csms(event: dict, context: BackgroundContext):
@@ -110,7 +108,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 # # using a different function, so we don't need to catch a change on any other manifest
                 # throws an error if any change to critical functions, so we do need catch those
                 _ = detect_manifest_changes(
-                    manifest, uploader_email=UPLOADER_EMAIL, session=session
+                    manifest, INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL, session=session
                 )
                 # with updates within API's detect_manifest_changes() itself, we can capture
                 # # these changes and insert new manifests here, eliminating NewManifestError altogether
@@ -119,12 +117,16 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 if data:
                     # relational hook
                     insert_manifest_from_json(
-                        manifest, uploader_email=UPLOADER_EMAIL, session=session
+                        manifest,
+                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
+                        session=session,
                     )
 
                     # schemas JSON blob hook
                     insert_manifest_into_blob(
-                        manifest, uploader_email=UPLOADER_EMAIL, session=session
+                        manifest,
+                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
+                        session=session,
                     )
 
                     email_msg.append(

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -36,10 +36,13 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
 
     `event` data is base64-encoded str(dict) in the form {"trial_id": "<trial>", "manifest_id": "<manifest>"}
         values for "trial_id" and "manifest_id" are used to see whether a manifest should be processed
-        special keyword "*" matches all
-        special case recasting via dict(eval(<decoded data>)) errors, dry run of all manifests
+        special value "*" matches all
+        fallback case if dict(data) raises error is dry run of all manifests
     NOTE This matching should be reconsidered once all CIDC / CSMS data is aligned and we're out of testing
     """
+    dry_run: bool = True
+
+    # TODO should we remove this matching once we're out of testing?
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data
@@ -50,33 +53,40 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         # just dry-run all of the manifest changes
         data: dict = {}
 
+    else:
+        if data:
+            if "trial_id" not in data or "manifest_id" not in data:
+                raise Exception(
+                    f"trial_id and manifest_id matching must both be provided, you provided: {data}"
+                )
+            dry_run = False
+
     email_msg = []
-    # TODO should we remove this matching once we're out of testing?
-    if data and ("manifest_id" not in data):
-        raise Exception(f"manifest_id matching must be provided, you provided: {data}")
 
-    elif not data:
+    if dry_run:
         if "data" in event:
-            event["data"] = extract_pubsub_data(event)
-        logger.warning(
-            f"manifest_id matching must be provided, no actual data changes will be made. Provided: {event!s}"
-        )
+            try:
+                # for human readability, but could be what errored above
+                event["data"] = extract_pubsub_data(event)
+            except Exception:
+                pass
+
+        logger.info(f"Dry-run call to update CIDC from CSMS. Provided: {event!s}")
         email_msg.append(
-            f"manifest_id matching must be provided, no actual data changes will be made. You provided: {event!s}"
+            f"To make changes, trial_id and manifest_id matching must both be provided in the event data. You provided: {event!s}"
         )
 
-    logger.info(
-        f"Call to update CIDC from CSMS matching: {data!s}\nIf {dict()!s}, then dry-run all."
-    )
+    else:
+        logger.info(f"Call to update CIDC from CSMS matching: {data!s}")
 
     with sqlalchemy_session() as session:
         url = "/manifests"
-        # only care about manifests that are qc_complete
+        # only care about manifests that are qc_complete and non-"legacy" ie not excluded
         match_conditions = ["status=qc_complete", "excluded=false"]
 
         # TODO should we remove this matching once we're out of testing?
         # add matching conditions if not matching all
-        if data.get("manifest_id", "*") != "*":
+        if not dry_run and data["manifest_id"] != "*":
             match_conditions.append(f"manifest_id={url_escape(data['manifest_id'])}")
 
         url += "?" + "&".join(match_conditions)
@@ -92,26 +102,22 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                     msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
                 )
             except Exception as e:
-                # if it doesn't have a consistent protocol_identifier, just skip it
+                # if it doesn't have a consistent protocol_identifier, just log the error and skip it
                 logger.error(str(e))
                 continue
 
             # trial_id matching has to be done via _get_and_check as it is only stored on the samples
-            if (
-                "trial_id" in data
-                and data["trial_id"] != "*"
-                and trial_id != data["trial_id"]
-            ):
+            if not dry_run and data["trial_id"] != "*" and trial_id != data["trial_id"]:
                 logger.info(
                     f"Skipping manifest {manifest.get('manifest_id')} from {trial_id} != {data['trial_id']}"
                 )
                 continue
 
             try:
+                # throws an error instead the catch if any change to critical fields, so we do need catch those too
                 try:
-                    # returns list of model instances, but we're only dealing with new manifests
+                    # returns `records`: list of model instances, but we're only dealing with new manifests
                     # # using a different function, so we don't need to catch a change on any other manifest
-                    # throws an error if any change to critical functions, so we do need catch those
                     _, changes = detect_manifest_changes(
                         manifest, uploader_email=INTERNAL_USER_EMAIL, session=session
                     )
@@ -124,6 +130,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         insert_manifest_from_json(
                             manifest,
                             uploader_email=INTERNAL_USER_EMAIL,
+                            dry_run=dry_run,
                             session=session,
                         )
 
@@ -131,6 +138,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         insert_manifest_into_blob(
                             manifest,
                             uploader_email=INTERNAL_USER_EMAIL,
+                            dry_run=dry_run,
                             session=session,
                         )
 
@@ -149,6 +157,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         )
 
                 else:
+                    # TODO in the future, should actually store returned records above and call insert_record_batch(records)
                     logger.info(
                         f"Changes found for {trial_id} manifest {manifest.get('manifest_id')}: {changes}"
                     )

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -108,7 +108,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 # # using a different function, so we don't need to catch a change on any other manifest
                 # throws an error if any change to critical functions, so we do need catch those
                 _ = detect_manifest_changes(
-                    manifest, INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL, session=session
+                    manifest, uploader_email=INTERNAL_USER_EMAIL, session=session
                 )
                 # with updates within API's detect_manifest_changes() itself, we can capture
                 # # these changes and insert new manifests here, eliminating NewManifestError altogether
@@ -117,16 +117,12 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 if data:
                     # relational hook
                     insert_manifest_from_json(
-                        manifest,
-                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
-                        session=session,
+                        manifest, uploader_email=INTERNAL_USER_EMAIL, session=session,
                     )
 
                     # schemas JSON blob hook
                     insert_manifest_into_blob(
-                        manifest,
-                        INTERNAL_USER_EMAIL=INTERNAL_USER_EMAIL,
-                        session=session,
+                        manifest, uploader_email=INTERNAL_USER_EMAIL, session=session,
                     )
 
                     email_msg.append(

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -87,16 +87,18 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         for manifest in manifest_iterator:
             # TODO should we remove this matching once we're out of testing?
             samples = manifest.get("samples", [])
-            trial_id = _get_and_check(
-                obj=samples,
-                key="protocol_identifier",
-                msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
-            )
-            # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
-            if len(samples) == 0:
+            try:
+                trial_id = _get_and_check(
+                    obj=samples,
+                    key="protocol_identifier",
+                    msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
+                )
+            except:
+                # if it doesn't have a consistent protocol_identifier, just skip it
                 continue
+
             # trial_id matching has to be done via _get_and_check as it is only stored on the samples
-            elif (
+            if (
                 "trial_id" in data
                 and data["trial_id"] != "*"
                 and trial_id != data["trial_id"]

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -76,9 +76,13 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         manifest_iterator: Iterator[Dict[str, Any]] = get_with_paging("/manifests")
 
         for manifest in manifest_iterator:
-            # only test those manifests that are qc_complete
+            # only test those manifests that are qc_complete AND have samples
             # if they're not qc_complete, _extract_info_from_manifest might throw errors from _get_and_check
-            if manifest.get("status") not in ("qc_complete", None):
+            # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
+            if (
+                manifest.get("status") not in ("qc_complete", None)
+                or len(manifest.get("samples", [])) == 0
+            ):
                 continue
 
             # TODO should we remove this matching once we're out of testing?

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -137,7 +137,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
 
             except Exception as e:
                 logger.error(
-                    f"Error from {e.__traceback__.tb_frame if hasattr(e, '__traceback__') and e.__traceback__ else None}: {e!r}"
+                    f"Error with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}"
                 )
                 email_msg.append(
                     f"Problem with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}",

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -87,6 +87,11 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
         for manifest in manifest_iterator:
             # TODO should we remove this matching once we're out of testing?
             samples = manifest.get("samples", [])
+            trial_id = _get_and_check(
+                obj=samples,
+                key="protocol_identifier",
+                msg=f"No consistent protocol_identifier defined for samples on manifest {manifest.get('manifest_id')}",
+            )
             # CSMS has qc_complete manifests that have no samples, which errors in _extract_info_from_manifest
             if len(samples) == 0:
                 continue
@@ -94,12 +99,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
             elif (
                 "trial_id" in data
                 and data["trial_id"] != "*"
-                and _get_and_check(
-                    obj=samples,
-                    key="protocol_identifier",
-                    msg=f"No consistent protocol_identifier defined for samples on manifest {data['manifest_id']}",
-                )
-                != data["trial_id"]
+                and trial_id != data["trial_id"]
             ):
                 continue
 
@@ -126,21 +126,23 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                     )
 
                     email_msg.append(
-                        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+                        f"New {trial_id} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
                     )
                 else:
                     email_msg.append(
-                        f"Would add new {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+                        f"Would add new {trial_id} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
                     )
 
             except Exception as e:
-                email_msg.append(
-                    f"Problem with {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')}: {e!s}",
+                logger.error(
+                    f"Error from {e.__traceback__.tb_frame if hasattr(e, '__traceback__') and e.__traceback__ else None}: {e!r}"
                 )
-            finally:
-                logger.info(f"Email: {email_msg}")
+                email_msg.append(
+                    f"Problem with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}",
+                )
 
         if email_msg:
+            logger.info(f"Email: {email_msg}")
             send_email(
                 CIDC_MAILING_LIST,
                 f"Summary of Update from CSMS: {datetime.now()}",

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -68,6 +68,8 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
             f"Both trial_id and manifest_id matching must be provided, no actual data changes will be made. You provided: {event!s}"
         )
 
+    logger.info(str(data))
+
     with sqlalchemy_session() as session:
         manifest_iterator: Iterator[Dict[str, Any]] = get_with_paging("/manifests")
 

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -72,7 +72,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
     with sqlalchemy_session() as session:
         url = "/manifests"
         # only care about manifests that are qc_complete
-        match_conditions = ["status=qc_complete"]
+        match_conditions = ["status=qc_complete", "excluded=false"]
 
         # TODO should we remove this matching once we're out of testing?
         # add matching conditions if not matching all

--- a/functions/settings.py
+++ b/functions/settings.py
@@ -46,6 +46,9 @@ AUTH0_CLIENT_SECRET = secrets.get("AUTH0_CLIENT_SECRET")
 # SendGrid config
 SENDGRID_API_KEY = secrets.get("SENDGRID_API_KEY")
 
+# Internal User For eg pseudo uploads
+INTERNAL_USER_EMAIL = secrets.get("INTERNAL_USER_EMAIL")
+
 # Check for configuration that must be defined if we're running in GCP
 if GCP_PROJECT:
     assert GOOGLE_DATA_BUCKET is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.35
+cidc-api-modules~=0.25.36

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.44
+cidc-api-modules~=0.25.45

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.28
+cidc-api-modules~=0.25.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.24
+cidc-api-modules~=0.25.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.37
+cidc-api-modules~=0.25.38

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.45
+cidc-api-modules~=0.25.46

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.43
+cidc-api-modules~=0.25.44

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.39
+cidc-api-modules~=0.25.40

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.25
+cidc-api-modules~=0.25.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-# The cidc_api_modules package
-cidc-api-modules~=0.25.23
+cidc-api-modules~=0.25.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.40
+cidc-api-modules~=0.25.41

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.42
+cidc-api-modules~=0.25.43

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.41
+cidc-api-modules~=0.25.42

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.36
+cidc-api-modules~=0.25.37

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.29
+cidc-api-modules~=0.25.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.38
+cidc-api-modules~=0.25.39

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.34
+cidc-api-modules~=0.25.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.26
+cidc-api-modules~=0.25.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.30
+cidc-api-modules~=0.25.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ statsmodels==0.12.2
 scikit_learn==0.24.2
 
 # The cidc_api_modules package
-cidc-api-modules~=0.25.22
+cidc-api-modules~=0.25.23

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -69,7 +69,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest3)[i] in args
-            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
+            assert kwargs.get("uploader_email") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -102,7 +102,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest2 in args
-        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
+        assert kwargs.get("uploader_email") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -137,7 +137,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest in args
-        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
+        assert kwargs.get("uploader_email") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -259,7 +259,7 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         args, kwargs = mock_detect.call_args_list[i]
         assert (manifest, manifest2)[i] in args
         print(kwargs)
-        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
+        assert kwargs.get("uploader_email") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
 
     for mock in [
@@ -279,7 +279,7 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest2)[i] in args
-            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
+            assert kwargs.get("uploader_email") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 from tests.util import make_pubsub_event, with_app_context
 
 import functions.csms
-from functions.csms import UPLOADER_EMAIL, update_cidc_from_csms
+
+# mock the env setting
+functions.csms.INTERNAL_USER_EMAIL = "user@email.com"
+
+from functions.csms import INTERNAL_USER_EMAIL, update_cidc_from_csms
 
 from cidc_api.models.templates.csms_api import NewManifestError
 from cidc_api.shared.emails import CIDC_MAILING_LIST
@@ -65,7 +69,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest3)[i] in args
-            assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -98,7 +102,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest2 in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -133,7 +137,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         assert mock.call_count == 1
         args, kwargs = mock.call_args_list[0]
         assert manifest in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]
@@ -254,7 +258,8 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
     for i in range(2):
         args, kwargs = mock_detect.call_args_list[i]
         assert (manifest, manifest2)[i] in args
-        assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+        print(kwargs)
+        assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
         assert "session" in kwargs
 
     for mock in [
@@ -274,7 +279,7 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         for i in range(2):
             args, kwargs = mock.call_args_list[i]
             assert (manifest, manifest2)[i] in args
-            assert kwargs.get("uploader_email") == UPLOADER_EMAIL
+            assert kwargs.get("INTERNAL_USER_EMAIL") == INTERNAL_USER_EMAIL
             assert "session" in kwargs
     mock_email.assert_called_once()
     args, kwargs = mock_email.call_args_list[0]

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -73,15 +73,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
         in args[2]
     )
 
@@ -106,15 +106,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')}"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
         not in args[2]
     )
 
@@ -141,15 +141,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}"
         not in args[2]
     )
     assert (
-        f"New {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
+        f"New {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')}"
         not in args[2]
     )
 
@@ -192,15 +192,15 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         in args[2]
     )
     assert (
-        f"Would add new {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"Would add new {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"Would add new {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"Would add new {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"Would add new {manifest3.get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
+        f"Would add new {manifest3.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest3.get('manifest_id')} with {len(manifest3.get('samples', []))} samples"
         in args[2]
     )
 
@@ -282,11 +282,11 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"New {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
+        f"New {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')} with {len(manifest.get('samples', []))} samples"
         in args[2]
     )
     assert (
-        f"New {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
+        f"New {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')} with {len(manifest2.get('samples', []))} samples"
         in args[2]
     )
 
@@ -301,11 +301,11 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        f"Problem with {manifest.get('protocol_identifier')} manifest {manifest.get('manifest_id')}: {Exception('foo')!s}"
+        f"Problem with {manifest.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest.get('manifest_id')}: {Exception('foo')!r}"
         in args[2]
     )
     assert (
-        f"Problem with {manifest2.get('protocol_identifier')} manifest {manifest2.get('manifest_id')}: {Exception('foo')!s}"
+        f"Problem with {manifest2.get('samples', [{}])[0].get('protocol_identifier')} manifest {manifest2.get('manifest_id')}: {Exception('foo')!r}"
         in args[2]
     )
     for mock in [

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -13,32 +13,21 @@ from cidc_api.shared.emails import CIDC_MAILING_LIST
 @with_app_context
 def test_update_cidc_from_csms_matching_some(monkeypatch):
     manifest = {
-        "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
     manifest2 = {
-        "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foobar",}],  # len != 0
     }
     manifest3 = {
-        "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
 
     mock_api_get = MagicMock()
     mock_api_get.return_value = [manifest, manifest2, manifest3]
-    mock_extract_info_from_manifest = lambda m, session: (
-        m["protocol_identifier"],
-        m["manifest_id"],
-        [],
-    )
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
-    monkeypatch.setattr(
-        functions.csms, "_extract_info_from_manifest", mock_extract_info_from_manifest
-    )
 
     mock_insert_json, mock_insert_blob = MagicMock(), MagicMock()
     monkeypatch.setattr(functions.csms, "insert_manifest_from_json", mock_insert_json)
@@ -69,10 +58,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     match_trial_event = make_pubsub_event(str({"trial_id": "foo", "manifest_id": "*"}))
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "trial_id=foo" in args[0] and "manifest_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id" not in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 2
@@ -106,10 +92,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "baz"}))
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "manifest_id=baz" in args[0] and "trial_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=baz" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -144,10 +127,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     )
     update_cidc_from_csms(match_trial_event, None)
     assert all(
-        [
-            "trial_id=foo" in args[0] and "manifest_id=bar" in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=bar" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 1
@@ -179,10 +159,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     mock_api_get.return_value = []
     match_trial_event = make_pubsub_event(str({"trial_id": "*", "manifest_id": "foo"}))
     assert all(
-        [
-            "manifest_id=foo" in args[0] and "trial_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id=foo" in args[0] for args, _ in mock_api_get.call_args_list]
     )
     update_cidc_from_csms(match_trial_event, None)
     for mock in [mock_insert_blob, mock_insert_json, mock_email]:
@@ -194,17 +171,14 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     mock_api_get.return_value = [manifest, manifest2, manifest3]
     update_cidc_from_csms({}, None)
     assert all(
-        [
-            "trial_id" not in args[0] and "manifest_id" not in args[0]
-            for args, _ in mock_api_get.call_args_list
-        ]
+        ["manifest_id" not in args[0] for args, _ in mock_api_get.call_args_list]
     )
     for mock in [mock_insert_blob, mock_insert_json]:
         assert mock.call_count == 0
     mock_logger.warning.assert_called_once()
     args, _ = mock_logger.warning.call_args_list[0]
     assert (
-        "Both trial_id and manifest_id matching must be provided, no actual data changes will be made."
+        "manifest_id matching must be provided, no actual data changes will be made."
         in args[0]
     )
 
@@ -214,7 +188,7 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
         "Summary of Update from CSMS:"
     )
     assert (
-        "Both trial_id and manifest_id matching must be provided, no actual data changes will be made."
+        "manifest_id matching must be provided, no actual data changes will be made."
         in args[2]
     )
     assert (
@@ -233,36 +207,24 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     # if bad-key but correctly formatted event data, error directly
     mock_detect.side_effect = Exception("foo")
     bad_event = make_pubsub_event(str({"key": "value"}))
-    with pytest.raises(
-        Exception, match="Both trial_id and manifest_id matching must be provided"
-    ):
+    with pytest.raises(Exception, match="manifest_id matching must be provided"):
         update_cidc_from_csms(bad_event, None)
 
 
 @with_app_context
 def test_update_cidc_from_csms_matching_all(monkeypatch):
     manifest = {
-        "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
     manifest2 = {
-        "protocol_identifier": "foo",
         "manifest_id": "baz",
-        "samples": [{}],  # len != 0
+        "samples": [{"protocol_identifier": "foo",}],  # len != 0
     }
 
     mock_api_get = MagicMock()
     mock_api_get.return_value = [manifest, manifest2]
-    mock_extract_info_from_manifest = lambda m, session: (
-        m["protocol_identifier"],
-        m["manifest_id"],
-        [],
-    )
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
-    monkeypatch.setattr(
-        functions.csms, "_extract_info_from_manifest", mock_extract_info_from_manifest
-    )
 
     mock_insert_json, mock_insert_blob = MagicMock(), MagicMock()
     monkeypatch.setattr(functions.csms, "insert_manifest_from_json", mock_insert_json)

--- a/tests/functions/test_csms.py
+++ b/tests/functions/test_csms.py
@@ -15,23 +15,29 @@ def test_update_cidc_from_csms_status_filtering(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],
     }
     manifest2 = {
         "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
         "status": "qc_complete",
     }
     manifest3 = {
         "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [],
+        "samples": [{}],  # len != 0
         "status": "draft",
+    }
+    manifest4 = {
+        "protocol_identifier": "foo",
+        "manifest_id": "biz",
+        "samples": [],
+        "status": "qc_complete",
     }
 
     mock_api_get = MagicMock()
-    mock_api_get.return_value = [manifest, manifest2, manifest3]
+    mock_api_get.return_value = [manifest, manifest2, manifest3, manifest4]
     mock_extract_info_from_manifest = MagicMock()
     mock_extract_info_from_manifest.return_value = ("trial", "manifest", [])
     monkeypatch.setattr(functions.csms, "get_with_paging", mock_api_get)
@@ -58,6 +64,10 @@ def test_update_cidc_from_csms_status_filtering(monkeypatch):
         manifest3 not in args
         for args, _ in mock_extract_info_from_manifest.call_args_list
     )
+    assert all(
+        manifest4 not in args
+        for args, _ in mock_extract_info_from_manifest.call_args_list
+    )
 
 
 @with_app_context
@@ -65,17 +75,17 @@ def test_update_cidc_from_csms_matching_some(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest2 = {
         "protocol_identifier": "foobar",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest3 = {
         "protocol_identifier": "foo",
         "manifest_id": "biz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
 
     mock_api_get = MagicMock()
@@ -259,12 +269,12 @@ def test_update_cidc_from_csms_matching_all(monkeypatch):
     manifest = {
         "protocol_identifier": "foo",
         "manifest_id": "bar",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
     manifest2 = {
         "protocol_identifier": "foo",
         "manifest_id": "baz",
-        "samples": [],
+        "samples": [{}],  # len != 0
     }
 
     mock_api_get = MagicMock()


### PR DESCRIPTION
## What

Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/630

CSMS:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/290 https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/291 API bumps
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/292 add INTERNAL_USER_EMAIL secret
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/293 bug fixes
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/294 logging
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/295 https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/296 https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/297 API bumps
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/298 ignore excluded manifests
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/299 catch errors when inserting new manifest
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/300 better dry_run functionality, API bump

WES analysis bump:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/301
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/513
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/631
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/303

## Remarks

Will also deploy CSMS code and infrastructure, therefore requiring defining the `INTERNAL_USER_EMAIL` secret
