### PR TITLE
CIDC-1187 1198 add CFn to grant all download permissions

### DIFF
--- a/.env
+++ b/.env
@@ -27,6 +27,7 @@ GOOGLE_EMAILS_TOPIC='emails'
 GOOGLE_PATIENT_SAMPLE_TOPIC='patient_sample_update'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC='artifact_upload'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC='assay_or_analysis_upload_complete'
+GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC='grant_download_perms'
 GOOGLE_EPHEMERAL_BUCKET='cidc-ephemeral-staging'
 
 AUTH0_DOMAIN='https://cidc-test.auth0.com'

--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ GOOGLE_EMAILS_TOPIC='emails'
 GOOGLE_PATIENT_SAMPLE_TOPIC='patient_sample_update'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC='artifact_upload'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC='assay_or_analysis_upload_complete'
-GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC='grant_download_perms'
+GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC='grant_download_perms'
 GOOGLE_EPHEMERAL_BUCKET='cidc-ephemeral-staging'
 
 AUTH0_DOMAIN='https://cidc-test.auth0.com'

--- a/.env.prod.yaml
+++ b/.env.prod.yaml
@@ -16,6 +16,8 @@ GOOGLE_EMAILS_TOPIC: "emails"
 GOOGLE_CLOUD_PROJECT: "cidc-dfci"
 GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
+GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
+
 GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"
 GOOGLE_EPHEMERAL_BUCKET: "cidc-ephemeral-prod"

--- a/.env.prod.yaml
+++ b/.env.prod.yaml
@@ -16,7 +16,7 @@ GOOGLE_EMAILS_TOPIC: "emails"
 GOOGLE_CLOUD_PROJECT: "cidc-dfci"
 GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
-GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
+GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
 
 GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"

--- a/.env.staging.yaml
+++ b/.env.staging.yaml
@@ -18,4 +18,5 @@ GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
 GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"
+GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
 GOOGLE_EPHEMERAL_BUCKET: "cidc-ephemeral-staging"

--- a/.env.staging.yaml
+++ b/.env.staging.yaml
@@ -18,5 +18,5 @@ GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
 GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"
-GOOGLE_GRANT_ALL_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
+GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
 GOOGLE_EPHEMERAL_BUCKET: "cidc-ephemeral-staging"

--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -10,3 +10,4 @@ from .auth0 import store_auth0_logs
 from .visualizations import vis_preprocessing
 from .users import disable_inactive_users, refresh_download_permissions
 from .csms import update_cidc_from_csms
+from .grant_permissions import grant_all_download_permissions

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+
+from .settings import ENV
+from .util import BackgroundContext, sqlalchemy_session
+
+from cidc_api.models import Permissions
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
+
+
+def grant_all_download_permissions(event: dict, context: BackgroundContext):
+    with sqlalchemy_session() as session:
+        try:
+            Permissions.grant_all_download_permissions(session=session)
+        except Exception as e:
+            logger.error(str(e))

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from functions import (
     disable_inactive_users,
     refresh_download_permissions,
     update_cidc_from_csms,
+    grant_all_download_permissions,
 )
 
 from flask import Flask, request, jsonify
@@ -22,6 +23,7 @@ topics_to_functions = {
     "patient_sample_update": derive_files_from_manifest_upload,
     "assay_or_analysis_upload": derive_files_from_assay_or_analysis_upload,
     "csms_trigger": update_cidc_from_csms,
+    "grant_download_perms": grant_all_download_permissions,
     "daily_cron": [
         store_auth0_logs,
         disable_inactive_users,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.50
+cidc-api-modules~=0.25.54

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -1,0 +1,15 @@
+import functions.grant_permissions
+from functions.grant_permissions import grant_all_download_permissions
+from unittest.mock import MagicMock
+
+
+def test_grant_all_download_permissions(monkeypatch):
+    mock_api_call = MagicMock()
+    monkeypatch.setattr(
+        functions.grant_permissions.Permissions,
+        "grant_all_download_permissions",
+        mock_api_call,
+    )
+
+    grant_all_download_permissions({}, None)
+    mock_api_call.assert_called_once()


### PR DESCRIPTION
REQUIRES `grant_download_perms` pubsub channel to be created on staging project before merging.

## What

Add function to trigger API's Permissions.grant_all_download_permissions
Parallels and supports https://github.com/CIMAC-CIDC/cidc-api-gae/pull/642

## Why

Currently, running over the 10mins that API times out at -- cloud functions can have a much longer time out that's under our control.

## How

single call to API's `Permissions.grant_all_download_permissions` function

## Remarks

May still be too slow, next idea is to include trial / upload matching to run in smaller batches.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
