### PR TITLE
CIDC-1198 add trial_id input to grant_all_download_permissions

### DIFF
--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from .settings import ENV
-from .util import BackgroundContext, sqlalchemy_session
+from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
 
 from cidc_api.models import Permissions
 
@@ -12,8 +12,23 @@ logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
 
 
 def grant_all_download_permissions(event: dict, context: BackgroundContext):
-    with sqlalchemy_session() as session:
-        try:
-            Permissions.grant_all_download_permissions(session=session)
-        except Exception as e:
-            logger.error(repr(e))
+    try:
+        # this returns the str, then convert it to a dict
+        # uses event["data"] and then assumes format, so will error if no/malformatted data
+        data: str = extract_pubsub_data(event)
+        data: dict = dict(eval(data))
+    except:
+        raise
+
+    else:
+        trial_id = data.get("trial_id")
+        if not trial_id:
+            raise Exception(f"trial_id must both be provided, you provided: {data}")
+
+        with sqlalchemy_session() as session:
+            try:
+                Permissions.grant_all_download_permissions(
+                    trial_id=trial_id, session=session
+                )
+            except Exception as e:
+                logger.error(repr(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.58
+cidc-api-modules~=0.25.59


### PR DESCRIPTION
## What & Why

Add optional `trial_id` kwarg from message data to `grant_all_download_permissions` to get around Google CFn timeouts from trying to do all the files in one go.

## How

Copied message parsing code from CSMS function
Pass as kwarg to `cidc_api.models.models.Permissions.grant_all_download_permissions` as added
https://github.com/CIMAC-CIDC/cidc-api-gae/pull/651

## Remarks

Still might need to be broken down further.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
