### PR TITLE
CIDC-1198 add assay filter to grant "all" download perms

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -10,4 +10,4 @@ from .auth0 import store_auth0_logs
 from .visualizations import vis_preprocessing
 from .users import disable_inactive_users, refresh_download_permissions
 from .csms import update_cidc_from_csms
-from .grant_permissions import grant_all_download_permissions
+from .grant_permissions import grant_download_permissions

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -11,7 +11,7 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
 
 
-def grant_all_download_permissions(event: dict, context: BackgroundContext):
+def grant_download_permissions(event: dict, context: BackgroundContext):
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data
@@ -21,14 +21,16 @@ def grant_all_download_permissions(event: dict, context: BackgroundContext):
         raise
 
     else:
-        trial_id = data.get("trial_id")
-        if not trial_id:
-            raise Exception(f"trial_id must both be provided, you provided: {data}")
+        trial_id, upload_type = data.get("trial_id"), data.get("upload_type")
+        if not trial_id or not upload_type:
+            raise Exception(
+                f"trial_id and upload_type must both be provided, you provided: {data}"
+            )
 
         with sqlalchemy_session() as session:
             try:
-                Permissions.grant_all_download_permissions(
-                    trial_id=trial_id, session=session
+                Permissions.grant_download_permissions(
+                    trial_id=trial_id, upload_type=upload_type, session=session
                 )
             except Exception as e:
                 logger.error(repr(e))

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from functions import (
     disable_inactive_users,
     refresh_download_permissions,
     update_cidc_from_csms,
-    grant_all_download_permissions,
+    grant_download_permissions,
 )
 
 from flask import Flask, request, jsonify
@@ -23,7 +23,7 @@ topics_to_functions = {
     "patient_sample_update": derive_files_from_manifest_upload,
     "assay_or_analysis_upload": derive_files_from_assay_or_analysis_upload,
     "csms_trigger": update_cidc_from_csms,
-    "grant_download_perms": grant_all_download_permissions,
+    "grant_download_perms": grant_download_permissions,
     "daily_cron": [
         store_auth0_logs,
         disable_inactive_users,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.61
+cidc-api-modules~=0.25.62

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -1,14 +1,14 @@
 import functions.grant_permissions
-from functions.grant_permissions import grant_all_download_permissions
+from functions.grant_permissions import grant_download_permissions
 import pytest
 from unittest.mock import MagicMock
 
 
-def test_grant_all_download_permissions(monkeypatch):
+def test_grant_download_permissions(monkeypatch):
     mock_api_call = MagicMock()
     monkeypatch.setattr(
         functions.grant_permissions.Permissions,
-        "grant_all_download_permissions",
+        "grant_download_permissions",
         mock_api_call,
     )
 
@@ -19,17 +19,29 @@ def test_grant_all_download_permissions(monkeypatch):
         functions.grant_permissions, "extract_pubsub_data", mock_extract_data
     )
     with pytest.raises(
-        Exception, match="trial_id must both be provided, you provided:"
+        Exception, match="trial_id and upload_type must both be provided, you provided:"
     ):
-        grant_all_download_permissions({}, None)
+        grant_download_permissions({}, None)
 
-    # with data response, calls
+    # incomplete/incorrect matching does nothing at all, just logging
     mock_extract_data = MagicMock()
-    mock_extract_data.return_value = str({"trial_id": "foo"})
+    mock_extract_data.return_value = str({"trial_id": "foo", "user": "baz"})
     monkeypatch.setattr(
         functions.grant_permissions, "extract_pubsub_data", mock_extract_data
     )
-    grant_all_download_permissions({}, None)
+    with pytest.raises(
+        Exception, match="trial_id and upload_type must both be provided, you provided:"
+    ):
+        grant_download_permissions({}, None)
+
+    # with data response, calls
+    mock_extract_data = MagicMock()
+    mock_extract_data.return_value = str({"trial_id": "foo", "upload_type": "bar"})
+    monkeypatch.setattr(
+        functions.grant_permissions, "extract_pubsub_data", mock_extract_data
+    )
+    grant_download_permissions({}, None)
     mock_api_call.assert_called_once()
     _, kwargs = mock_api_call.call_args_list[0]
     assert kwargs.get("trial_id") == "foo"
+    assert kwargs.get("upload_type") == "bar"


### PR DESCRIPTION
Parallels
https://github.com/CIMAC-CIDC/cidc-api-gae/pull/654

## What

Add assay filter to grant "all" download perms
Keep the cloud function name itself as `grant_all_download_permissions`  for now

## Why

Describe what motivated this Pull Request and why this was necessary. Link to the corresponding change in Schemas/API, and relevant JIRA Issue. Ex. Closes CIDC-1086

## How

- Changed `\*_all_download_permissions to `\*_download_permissions`
  - CFn name itself remains `grant_all_download_permissions`  but all code and functions lose the `_all`
- use new `upload_type` kwarg on `cidc_api.models.Permissions.grant_download_permissions`

## Remarks

Still might be too long -- next idea is to find some sort of paging within the assay type, possibly by having a CFn to grant for a particular set of files that can be automatically published from an initial manual pubsub message to act as parallelization instead of continuing to reduce the scope of the action below the trial / assay level.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
