### PR TITLE
CIDC-1198 CI name fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             topic: csms_trigger
             timeout: 540
             memory: 1024
-          - name: grant_all_download_permissions
+          - name: grant_download_permissions
             topic: grant_download_perms
             timeout: 540
             memory: 1024


### PR DESCRIPTION
## What

Correctly point to renamed `grant_download_permissions` function in CI

## Why

I misunderstood what the name in the CI configuration was referencing -- it's the name of the function in `main.py`.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
