### PR TITLE
CIDC-1198 add revoke, user_email_list, docs, None handling

### DIFF
--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 import logging
 import sys
-from typing import Dict, List
+from typing import List
 
 from .settings import ENV, GOOGLE_WORKER_TOPIC
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
@@ -10,7 +11,11 @@ from cidc_api.shared.gcloud_client import (
     _encode_and_publish,
     get_blob_names,
     grant_download_access_to_blob_names,
+    send_email,
+    revoke_download_access_from_blob_names,
 )
+from cidc_api.shared.emails import CIDC_MAILING_LIST
+
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(sys.stdout))
@@ -18,6 +23,24 @@ logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
 
 
 def grant_download_permissions(event: dict, context: BackgroundContext):
+    """
+    Takes the pubsub event data as dict
+
+    Parameters
+    ----------
+    trial_id: Optional[str]
+        the trial_id for the trial to affect
+    upload_type: Optional[str]
+        the upload_type, as stored in the Permissions table
+
+    Optional Parameters
+    -------------------
+    revoke: Optional[bool] = False
+        if explicitly set to True, revoke instead of grant
+    user_email_list: List[str]
+        a comma separated list of user emails to apply the permissions for
+        otherwise loaded from the database for all affected users
+    """
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data
@@ -27,37 +50,50 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
         raise
 
     else:
-        trial_id, upload_type = data.get("trial_id"), data.get("upload_type")
-        if not trial_id or not upload_type:
+        # ---- Run API through here ----
+        # handle special values for cross-assay/trial
+        # API functions and database use None to mean all
+        # but require explicit passing of None to match
+        if "trial_id" not in data or "upload_type" not in data:
             raise Exception(
-                f"trial_id and upload_type must both be provided, you provided: {data}"
+                f"trial_id and upload_type must both be provided, you provided: {data}\nProvide None for cross-trial/assay matching"
             )
+        trial_id, upload_type = data.get("trial_id"), data.get("upload_type")
+
+        revoke = data.get("revoke", False)
 
         with sqlalchemy_session() as session:
             try:
-                permissions_list: List[Permissions] = Permissions.get_for_trial_type(
-                    trial_id=trial_id, upload_type=upload_type, session=session
-                )
-                user_list: List[Users] = [
-                    Users.find_by_id(id=perm.granted_to_user, session=session)
-                    for perm in permissions_list
-                ]
-                user_email_list: List[str] = [u.email for u in user_list]
+                if "user_email_list" in data:
+                    user_email_list: List[str] = data["user_email_list"]
 
-                blob_list: List = get_blob_names(
+                else:
+                    permissions_list: List[
+                        Permissions
+                    ] = Permissions.get_for_trial_type(
+                        trial_id=trial_id, upload_type=upload_type, session=session
+                    )
+                    user_list: List[Users] = [
+                        Users.find_by_id(id=perm.granted_to_user, session=session)
+                        for perm in permissions_list
+                    ]
+                    user_email_list: List[str] = [u.email for u in user_list]
+
+                blob_name_list: List = get_blob_names(
                     trial_id=trial_id, upload_type=upload_type
                 )
 
                 n = 100  # number_of_blobs_per_chunk
-                blob_list_chunks = [
-                    blob_list[i : i + n] for i in range(0, len(blob_list), n)
+                blob_name_list_chunks = [
+                    blob_name_list[i : i + n] for i in range(0, len(blob_name_list), n)
                 ]
 
-                for chunk in blob_list_chunks:
+                for chunk in blob_name_list_chunks:
                     kwargs = {
                         "_fn": "permissions_worker",
-                        "user_list": user_email_list,
-                        "blob_list": chunk,
+                        "user_email_list": user_email_list,
+                        "blob_name_list": chunk,
+                        "revoke": revoke,
                     }
                     report = _encode_and_publish(str(kwargs), GOOGLE_WORKER_TOPIC)
                     # Wait for response from pub/sub
@@ -65,20 +101,41 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
                         report.result()
 
             except Exception as e:
-                logger.error(repr(e))
+                logger.error(f"Error: {e}", exc_info=True)
+                send_email(
+                    CIDC_MAILING_LIST,
+                    f"Error granting permissions: {datetime.now()}",
+                    f"For {data}\r\nSee logs for more info\r\n{e}",
+                )
+                raise e
 
 
-def permissions_worker(user_list: List[str] = [], blob_list: List[str] = []):
-    if not user_list or not blob_list:
-        data = {"user_list": user_list, "blob_list": blob_list}
-        raise Exception(
-            f"Permissions worker: user_list and blob_list must both be provided, you provided: {data}"
+def permissions_worker(
+    user_email_list: List[str] = [],
+    blob_name_list: List[str] = [],
+    revoke: bool = False,
+):
+    if not user_email_list or not blob_name_list:
+        data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}
+        raise ValueError(
+            f"Permissions worker: user_email_list and blob_name_list must both be provided, you provided: {data}"
         )
 
     try:
-        # scvannost - I named these params suboptimally in the API; tech debt to fix
-        grant_download_access_to_blob_names(
-            user_email=user_list, blob_name_list=blob_list
-        )
+        if revoke:
+            revoke_download_access_from_blob_names(
+                user_email_list=user_email_list, blob_name_list=blob_name_list
+            )
+        else:
+            grant_download_access_to_blob_names(
+                user_email_list=user_email_list, blob_name_list=blob_name_list
+            )
     except Exception as e:
-        logger.error(repr(e))
+        data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}
+        logger.error(f"Error on {data}:\nError:{e}", exc_info=True)
+        send_email(
+            CIDC_MAILING_LIST,
+            f"Error granting permissions: {datetime.now()}",
+            f"For {data}\r\nSee logs for more info\r\n{e}",
+        )
+        raise e

--- a/functions/worker.py
+++ b/functions/worker.py
@@ -3,7 +3,18 @@ from .util import BackgroundContext, extract_pubsub_data
 
 
 def worker(event: dict, context: BackgroundContext):
-    """For use in parallelizing cloud function code"""
+    """
+    For use in parallelizing cloud function code
+    Takes the pubsub event data as dict
+
+    Parameters
+    ----------
+    _fn : str
+        the name of the function to call
+        must be handled in the switch below to work
+    **kwargs
+        passed to _fn
+    """
     try:
         # this returns the str, then convert it to a dict
         # uses event["data"] and then assumes format, so will error if no/malformatted data

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.65
+cidc-api-modules~=0.25.66

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -1,5 +1,5 @@
 import functions.grant_permissions
-from functions.grant_permissions import grant_download_permissions
+from functions.grant_permissions import grant_download_permissions, permissions_worker
 from functions.settings import GOOGLE_WORKER_TOPIC
 import pytest
 from unittest.mock import MagicMock
@@ -15,19 +15,23 @@ def test_grant_download_permissions(monkeypatch):
         mock_permissions_list,
     )
 
-    users = [MagicMock(), MagicMock()]
-    user_emails = ["foo@bar.com", "user@test.com"]
-    for user, email in zip(users, user_emails):
+    user_list = [MagicMock(), MagicMock()]
+    user_email_list = ["foo@bar.com", "user@test.com"]
+    for user, email in zip(user_list, user_email_list):
         user.email = email
 
     monkeypatch.setattr(
-        functions.grant_permissions.Users, "find_by_id", lambda id, session: users.pop()
+        functions.grant_permissions.Users,
+        "find_by_id",
+        lambda id, session: user_list.pop(),
     )
 
-    mock_blob_list = MagicMock()
+    mock_blob_name_list = MagicMock()
     # need more than 100 to test chunking
-    mock_blob_list.return_value = [f"blob{n}" for n in range(100 + 50)]
-    monkeypatch.setattr(functions.grant_permissions, "get_blob_names", mock_blob_list)
+    mock_blob_name_list.return_value = [f"blob{n}" for n in range(100 + 50)]
+    monkeypatch.setattr(
+        functions.grant_permissions, "get_blob_names", mock_blob_name_list
+    )
 
     mock_encode_and_publish = MagicMock()
     monkeypatch.setattr(
@@ -47,7 +51,7 @@ def test_grant_download_permissions(monkeypatch):
 
     # incomplete/incorrect matching does nothing at all, just logging
     mock_extract_data = MagicMock()
-    mock_extract_data.return_value = str({"trial_id": "foo", "user": "baz"})
+    mock_extract_data.return_value = str({"trial_id": "foo", "user_email_list": "baz"})
     monkeypatch.setattr(
         functions.grant_permissions, "extract_pubsub_data", mock_extract_data
     )
@@ -67,7 +71,7 @@ def test_grant_download_permissions(monkeypatch):
     _, kwargs = mock_permissions_list.call_args_list[0]
     assert kwargs.get("trial_id") == "foo"
     assert kwargs.get("upload_type") == "bar"
-    mock_blob_list.assert_called_once_with(trial_id="foo", upload_type="bar")
+    mock_blob_name_list.assert_called_once_with(trial_id="foo", upload_type="bar")
 
     assert mock_encode_and_publish.call_count == 2
     call1, call2 = mock_encode_and_publish.call_args_list
@@ -75,11 +79,86 @@ def test_grant_download_permissions(monkeypatch):
 
     assert eval(call1[0][0]) == {
         "_fn": "permissions_worker",
-        "user_list": user_emails[::-1],  # pop above inverts
-        "blob_list": mock_blob_list.return_value[:100],
+        "user_email_list": user_email_list[::-1],  # pop above inverts
+        "blob_name_list": mock_blob_name_list.return_value[:100],
+        "revoke": False,
     }
     assert eval(call2[0][0]) == {
         "_fn": "permissions_worker",
-        "user_list": user_emails[::-1],  # pop above inverts
-        "blob_list": mock_blob_list.return_value[100:],
+        "user_email_list": user_email_list[::-1],  # pop above inverts
+        "blob_name_list": mock_blob_name_list.return_value[100:],
+        "revoke": False,
     }
+
+    # with revoke: True, passing revoke: True
+    # passing user_email_list doesn't get the Permissions or users
+    mock_find_user = MagicMock()
+    monkeypatch.setattr(functions.grant_permissions.Users, "find_by_id", mock_find_user)
+    mock_encode_and_publish.reset_mock()  # we're checking this
+    mock_permissions_list.reset_mock()  # shouldn't be called
+
+    mock_extract_data.return_value = str(
+        {
+            "trial_id": "foo",
+            "upload_type": "bar",
+            "user_email_list": user_email_list,
+            "revoke": True,
+        }
+    )
+    grant_download_permissions({}, None)
+
+    mock_permissions_list.assert_not_called()
+    mock_find_user.assert_not_called()
+
+    assert mock_encode_and_publish.call_count == 2
+    call1, call2 = mock_encode_and_publish.call_args_list
+    assert call1[0][1] == GOOGLE_WORKER_TOPIC and call2[0][1] == GOOGLE_WORKER_TOPIC
+
+    assert eval(call1[0][0]) == {
+        "_fn": "permissions_worker",
+        "user_email_list": user_email_list,
+        "blob_name_list": mock_blob_name_list.return_value[:100],
+        "revoke": True,
+    }
+    assert eval(call2[0][0]) == {
+        "_fn": "permissions_worker",
+        "user_email_list": user_email_list,
+        "blob_name_list": mock_blob_name_list.return_value[100:],
+        "revoke": True,
+    }
+
+
+def test_permissions_worker(monkeypatch):
+    user_email_list = ["foo@bar.com", "user@test.com"]
+    blob_name_list = [f"blob{n}" for n in range(100)]
+
+    with pytest.raises(
+        ValueError, match="user_email_list and blob_name_list must both be provided"
+    ):
+        permissions_worker()
+
+    mock_grant, mock_revoke = MagicMock(), MagicMock()
+    monkeypatch.setattr(
+        functions.grant_permissions, "grant_download_access_to_blob_names", mock_grant
+    )
+    monkeypatch.setattr(
+        functions.grant_permissions,
+        "revoke_download_access_from_blob_names",
+        mock_revoke,
+    )
+    permissions_worker(
+        user_email_list=user_email_list, blob_name_list=blob_name_list, revoke=False
+    )
+    mock_grant.assert_called_with(
+        user_email_list=user_email_list, blob_name_list=blob_name_list
+    )
+    mock_revoke.assert_not_called()
+
+    mock_grant.reset_mock()
+    permissions_worker(
+        user_email_list=user_email_list, blob_name_list=blob_name_list, revoke=True
+    )
+    mock_grant.assert_not_called()
+    mock_revoke.assert_called_with(
+        user_email_list=user_email_list, blob_name_list=blob_name_list
+    )


### PR DESCRIPTION
Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/658

## What

Extend grant download permissions CFn functionality to handled all permissions operations.

## Why

Supports https://github.com/CIMAC-CIDC/cidc-api-gae/pull/658 's revoking permissions and cross trial/upload

## How

- add revoke kwarg to both grant permissions function and permission worker
- allow for passing None for trial or upload type; already handled and widely used in the API
- add user_email_list to allowed for more targeted scopes
- update tests to match
- add a bunch of documentation

## Remarks

While list_blobs for cross trial / upload types could time out, direct local CLI testing with staging indicates it should be fine.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x]  Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
