### PR TITLE
CIDC-1235 bump API version, send email of disabled emails

### DIFF
--- a/functions/users.py
+++ b/functions/users.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
+from typing import List
 
 from cidc_api.models import Users, Permissions
+from cidc_api.shared.gcloud_client import send_email
+from cidc_api.shared.emails import CIDC_MAILING_LIST
 
 from .util import sqlalchemy_session
 
@@ -9,10 +12,14 @@ def disable_inactive_users(*args):
     """Disable any users who have become inactive."""
     with sqlalchemy_session() as session:
         print("Disabling inactive users...")
-        disabled = Users.disable_inactive_users(session=session)
-        for u in disabled:
-            print(f"Disabled inactive: {u[0]}")
-        print("done.")
+        disabled: List[str] = Users.disable_inactive_users(session=session)
+        print(f"Disabled inactive: {disabled}")
+        if len(disabled):
+            send_email(
+                CIDC_MAILING_LIST,
+                f"Disabled inactivate users: {datetime.now()}",
+                f"Diabled following users: {disabled}",
+            )
 
 
 def refresh_download_permissions(*args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.25.67
+cidc-api-modules~=0.25.68


### PR DESCRIPTION
## What

Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/660
Sends email when users are disabled for inactivity

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
