### PR TITLE
CIDC-1240 improve ACL handling for edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 1 Feb 2022
+
+- `fixed` handling of subcases when applying permissions to multiple sets of files
+- `added` flag for group email for BioFX group
+
+## 31 Jan 2022
+
+- `changed` API dependency for schemas bump for backward-compatible WES analysis
+
 ## 27 Jan 2022
 
 - `removed` non-ACL based download permissions systems for production

--- a/functions/uploads.py
+++ b/functions/uploads.py
@@ -188,6 +188,7 @@ def ingest_upload(event: dict, context: BackgroundContext):
                 "trial_id": trial_id,
                 "upload_type": job.upload_type,
                 "user_email_list": [analysis_group_email],
+                "is_group": True,
             }
             report = _encode_and_publish(
                 str(kwargs), GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.1
+cidc-api-modules~=0.26.2

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -178,6 +178,7 @@ def test_ingest_upload(caplog, monkeypatch):
                     "trial_id": TRIAL_ID,
                     "upload_type": job.upload_type,
                     "user_email_list": ["analysis-group@email"],
+                    "is_group": True,
                 }
             ),
             GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC,


### PR DESCRIPTION
Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/664

## What

- Fix handling of subcases when applying permissions to multiple sets of files
- Add flag for group email for BioFX group

## Why

Discovered in initial ACL deployment and reapplying broad permissions.

- BioFX group is throwing errors because it's being treated as a user
- Need to know which users are to be applied to each trial / upload combo when applying broad permissions

## How

- Add optional `is_group: bool` flag to the messages for `grant_download_permissions`, pass through to `permissions_worker`, and pass to API's `[grant/revoke]_download_access_to_blob_names`
- If a `user_email_list` is not provided, load from the database using API's new `models.models.Permissions.get_user_emails_for_trial_upload`
  - returns structure with all user emails for each trial / upload combo affected
  - then loop through this structure to make the calls for `permissions_worker`

## Remarks

Does **NOT** resolve ETag issue around re-enabling a user

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
