### PR TITLE
CIDC-1301 api bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 25 Mar 2022
+
+- `changed` API (schemas) version bump for regex version peg to prevent errors
+
 ## 1 Feb 2022
 
 - `fixed` handling of subcases when applying permissions to multiple sets of files

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.8
+cidc-api-modules~=0.26.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.6
+cidc-api-modules~=0.26.8


### PR DESCRIPTION
## What

Bump API dependency to bump `schemas` dependency to peg version for `regex` library to prevent errors in date format validation.

## Why

`regex==2022.3.15` throws `bad escape \d at position` when validating dates in manifest uploads

## How

Peg to last known working version.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
