### PR TITLE
CIDC-1339 bump api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 20 May 2022
+
+- `changed` bump API for schemas bump for new ctDNA option for manifest assay_type
+
 ## 28 Apr 2022
 
 - `changed` pytest, black, click, api version bumps

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.10
+cidc-api-modules~=0.26.12


### PR DESCRIPTION
Parallels https://github.com/CIMAC-CIDC/cidc-schemas/pull/524 and https://github.com/CIMAC-CIDC/cidc-api-gae/pull/691

## What

Bump API to bump schemas to add ctDNA for assay_type in blood manifests

## Why

- [CIDC-1339](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1339) Add ctDNA to manifest assay_type options

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
