### PR TITLE
CIDC-1422, 1424, 1429 deploys: schemas and permissions tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 11 Aug 2022
+
+- `changed` bump API for clinical data NOT included in cross-assay permissions
+
 ## 9 Aug 2022
 
 - `added` bump API for schemas bump for hande manifest req relaxation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 15 Aug 2022
+
+- `changed` bump API for ctdna analysis nulls, hande jpeg, and upload perm fix
+
 ## 11 Aug 2022
 
 - `changed` bump API for clinical data NOT included in cross-assay permissions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 9 Aug 2022
+
+- `added` bump API for schemas bump for hande manifest req relaxation
+
 ## 2 Aug 2022
 
 - `added` pinned flask version to fix error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 ## 2 Aug 2022
 
+- `added` pinned flask version to fix error
+
+## 2 Aug 2022
+
 - `changed` bump API for schemas bump for hande req relaxation
 
 ## 27 Jul 2022

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.25
+cidc-api-modules~=0.26.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ google-cloud-storage~=1.35.0
 google-cloud-logging==1.13.0
 psycopg2-binary==2.8.3
 flask-sqlalchemy~=2.4.0
+flask==2.0.3
 werkzeug==2.0.3
 itsdangerous==2.0.1
 sqlalchemy~=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.24
+cidc-api-modules~=0.26.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.26
+cidc-api-modules~=0.26.27


### PR DESCRIPTION
Deploys:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/374
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/375
Parallels:
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/724

## What

- Change cross-assay single-trial permission to NOT include the clinical data
- Bump schemas
  - Add possibility for string values to some ctdna analysis columns for null values
- Include cross-trial and cross-assay permissions when implementing them for a new upload job
  - wasn't including any permission where either `trial_id` or `upload_type` was null

## Why

- [CIDC-1422](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1422) 10057 ctdna analysis contains null values
- [CIDC-1424](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1424) Make changes to portal access provider to simplify enabling clinical data access
- [CIDC-1429](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1429) Bug of having to re-select permissions in order for user to have them
  - If not applied at upload, then need to reclick or pubsub-trigger afterwards to implement correct permissions on new files.
Not necessarily the only source of this issue, but definitely contributes

## How

Schemas and API changes

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
