### PR TITLE
CIDC-1425 fix bug where derived files not getting correct upload type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 23 Aug 2022
+
+- `fixed` bug putting wrong upload_type on derived files
+
 ## 17 Aug 2022
 
 - `changed` bump API for microbiome metadata template changes and new shipping lab

--- a/functions/upload_postprocessing.py
+++ b/functions/upload_postprocessing.py
@@ -83,11 +83,11 @@ def _derive_files_from_upload(trial_id: str, upload_type: str, session):
 
         # Save to database
         df_record = DownloadableFiles.create_from_blob(
-            trial_record.trial_id,
-            artifact.file_type,
-            artifact.data_format,
-            facet_group,
-            blob,
+            trial_id=trial_record.trial_id,
+            upload_type=upload_type,
+            data_format=artifact.data_format,
+            facet_group=facet_group,
+            blob=blob,
             session=session,
             alert_artifact_upload=True,
         )


### PR DESCRIPTION
## What

Fix bug putting wrong `upload_type` on derived files

## Why

[CIDC-1425](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1425) Fix Olink Study Wide file download
- derived files were given an incorrect `upload_type` and so were not able to be downloaded through the API due to upload type-based permission checks

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
