### PR TITLE
CIDC-1425 bugfix deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 15 Aug 2022
+
+- `changed` bump API for ctdna analysis nulls, hande jpeg, and upload perm fix
+
 ## 11 Aug 2022
 
 - `changed` bump API for clinical data NOT included in cross-assay permissions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 23 Aug 2022
+
+- `fixed` bug putting wrong upload_type on derived files
+
 ## 17 Aug 2022
 
 - `changed` bump API for microbiome metadata template changes and new shipping lab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 17 Aug 2022
+
+- `changed` bump API for microbiome metadata template changes and new shipping lab
+
 ## 15 Aug 2022
 
 - `changed` bump API for ctdna analysis nulls, hande jpeg, and upload perm fix

--- a/functions/upload_postprocessing.py
+++ b/functions/upload_postprocessing.py
@@ -83,11 +83,11 @@ def _derive_files_from_upload(trial_id: str, upload_type: str, session):
 
         # Save to database
         df_record = DownloadableFiles.create_from_blob(
-            trial_record.trial_id,
-            artifact.file_type,
-            artifact.data_format,
-            facet_group,
-            blob,
+            trial_id=trial_record.trial_id,
+            upload_type=upload_type,
+            data_format=artifact.data_format,
+            facet_group=facet_group,
+            blob=blob,
             session=session,
             alert_artifact_upload=True,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.27
+cidc-api-modules~=0.26.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.26
+cidc-api-modules~=0.26.27

--- a/tests/functions/test_upload_postprocessing.py
+++ b/tests/functions/test_upload_postprocessing.py
@@ -90,5 +90,5 @@ def test_derive_files_from_upload(monkeypatch):
     upload_to_data_bucket.assert_called()
     create_from_blob.assert_called()
     session.commit.assert_called()
-    assert blob in create_from_blob.call_args[0]
+    assert blob in create_from_blob.call_args[1].values()
     assert downloadable_file.analysis_friendly is True


### PR DESCRIPTION
## What

Fix bug putting wrong upload_type on derived files

## Why

[CIDC-1425](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1425) Fix Olink Study Wide file download

derived files were given an incorrect upload_type and so were not able to be downloaded through the API due to upload type-based permission checks

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
