### PR TITLE
CIDC-1278 api/schemas bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.28
+cidc-api-modules~=0.26.31


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/549
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/729

## What

API bump for schemas bump for docs update / DM clean-up

## Why

[CIDC-1278](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1278) Update portal schema docs

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
