### PR TITLE
CIDC-1484 API bump to add pact user role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 01 Oct 2022
+
+- `changed` API bump for new PACT User role
+
 ## 16 Sep 2022
 
 - `changed` bump API for encrypting participant IDs

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -162,6 +162,8 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
             logger.info(f"Email: {email_msg}")
             send_email(
                 CIDC_MAILING_LIST,
-                f"[DEV ALERT]({ENV})" + ("Error" if email_error else "Success") + f" updating from CSMS: {datetime.now()}",
+                f"[DEV ALERT]({ENV})"
+                + ("Error" if email_error else "Success")
+                + f" updating from CSMS: {datetime.now()}",
                 html_content="<br />".join(email_msg),
             )

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -56,7 +56,8 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 )
             dry_run = False
 
-    email_msg = []
+    email_msg: str = []
+    email_error: bool = False
 
     if dry_run:
         if "data" in event:
@@ -155,11 +156,12 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 email_msg.append(
                     f"Problem with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}"
                 )
+                email_error = True
 
         if email_msg:
             logger.info(f"Email: {email_msg}")
             send_email(
                 CIDC_MAILING_LIST,
-                f"[DEV ALERT]({ENV}) Error updating from CSMS: {datetime.now()}",
+                f"[DEV ALERT]({ENV})" + ("Error" if email_error else "Success") + f" updating from CSMS: {datetime.now()}",
                 html_content="<br />".join(email_msg),
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.1
+cidc-api-modules~=0.27.2


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/733

## What

Bump API to add a role for PACT users that is equivalent to the Network viewer role.

## Why

- [CIDC-1484](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1484) Add PACT User Type
- 
## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
