### PR TITLE
CIDC-1484 Prod deploy: API bump to add pact user role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 16 Sep 2022
+
+- `changed` bump API for encrypting participant IDs
+
 ## 15 Sep 2022
 
 - `changed` bump API for removal of relational tables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 15 Sep 2022
+
+- `changed` bump API for removal of relational tables
+- `remove` function calls to removed functions in API
+
+## 14 Sep 2022
+
+- `changed` bump API for new docs / schemas tweaks
+
 ## 23 Aug 2022
 
 - `fixed` bug putting wrong upload_type on derived files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 01 Oct 2022
+
+- `changed` API bump for new PACT User role
+
 ## 16 Sep 2022
 
 - `changed` bump API for encrypting participant IDs

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -56,7 +56,8 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 )
             dry_run = False
 
-    email_msg = []
+    email_msg: str = []
+    email_error: bool = False
 
     if dry_run:
         if "data" in event:
@@ -155,11 +156,14 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                 email_msg.append(
                     f"Problem with {trial_id} manifest {manifest.get('manifest_id')}: {e!r}"
                 )
+                email_error = True
 
         if email_msg:
             logger.info(f"Email: {email_msg}")
             send_email(
                 CIDC_MAILING_LIST,
-                f"[DEV ALERT]({ENV}) Error updating from CSMS: {datetime.now()}",
+                f"[DEV ALERT]({ENV})"
+                + ("Error" if email_error else "Success")
+                + f" updating from CSMS: {datetime.now()}",
                 html_content="<br />".join(email_msg),
             )

--- a/functions/csms.py
+++ b/functions/csms.py
@@ -8,10 +8,9 @@ from .settings import ENV, INTERNAL_USER_EMAIL
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
 
 from cidc_api.csms import get_with_paging
-from cidc_api.models.templates.csms_api import (
+from cidc_api.models.csms_api import (
     _get_and_check,
     detect_manifest_changes,
-    insert_manifest_from_json,
     insert_manifest_into_blob,
     NewManifestError,
 )
@@ -112,9 +111,8 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
             try:
                 # throws an error instead the catch if any change to critical fields, so we do need catch those too
                 try:
-                    # returns `records`: list of model instances, but we're only dealing with new manifests
-                    # # using a different function, so we don't need to catch a change on any other manifest
-                    _, changes = detect_manifest_changes(
+                    # we're only dealing with new manifests, so we don't need to catch a change on any other manifest
+                    changes = detect_manifest_changes(
                         manifest, uploader_email=INTERNAL_USER_EMAIL, session=session
                     )
                     # with updates within API's detect_manifest_changes() itself, we can capture
@@ -122,14 +120,6 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
 
                 except NewManifestError:
                     if data:
-                        # relational hook
-                        insert_manifest_from_json(
-                            manifest,
-                            uploader_email=INTERNAL_USER_EMAIL,
-                            dry_run=dry_run,
-                            session=session,
-                        )
-
                         # schemas JSON blob hook
                         insert_manifest_into_blob(
                             manifest,
@@ -153,7 +143,7 @@ def update_cidc_from_csms(event: dict, context: BackgroundContext):
                         )
 
                 else:
-                    # TODO in the future, should actually store returned records above and call insert_record_batch(records)
+                    # TODO in the future, should actually handle chanes records above and handle
                     logger.info(
                         f"Changes found for {trial_id} manifest {manifest.get('manifest_id')}: {changes}"
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.1
+cidc-api-modules~=0.27.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.26.31
+cidc-api-modules~=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.0
+cidc-api-modules~=0.27.1


### PR DESCRIPTION
Deploys:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/386

Parallels:
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/734

## What

Bump API to add a role for PACT users that is equivalent to the Network viewer role.

## Why

- [CIDC-1484](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1484) Add PACT User Type

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed