### PR TITLE
CIDC-1490 api bump for bug fix for permissions on new uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 06 Oct 2022
+
+- `changed` API bump to fix bug in permissions for new uploads
+
 ## 01 Oct 2022
 
 - `changed` API bump for new PACT User role

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.2
+cidc-api-modules~=0.27.3


### PR DESCRIPTION
Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/735

## What

A user informed CIDC that they did not have the correct access, leading to discovery that new uploads did not apply the correct permissions. Code to separate clinical data from cross-assay permissions introduced error in API.

## Why

- [CIDC-1490](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1490) Fix bug in permissions on new uploads

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
