### PR TITLE
CIDC-1486 add bigquery to permission refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 13 Oct 2022
+
+- `changed` API bump for bigquery permission changes
+- `added` granting bigquery permissions to download perm refresh
+
 ## 12 Oct 2022
 
 - `changed` API bump for switching staging uploader role to temp replacement

--- a/functions/users.py
+++ b/functions/users.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import List
 
 from cidc_api.models import Users, Permissions
-from cidc_api.shared.gcloud_client import send_email
+from cidc_api.shared.gcloud_client import send_email, grant_bigquery_access
 from cidc_api.shared.emails import CIDC_MAILING_LIST
 
 from .settings import ENV
@@ -44,3 +44,4 @@ def refresh_download_permissions(*args):
         for user in active_users:
             print(f"Refreshing IAM download permissions for {user.email}")
             Permissions.grant_iam_permissions(user, session=session)
+        grant_bigquery_access([user.email for user in active_users])

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.5
+cidc-api-modules~=0.27.6

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -28,5 +28,10 @@ def test_refresh_download_permissions(monkeypatch):
     PermissionsMock.grant_iam_permissions = MagicMock()
     monkeypatch.setattr(users, "Permissions", PermissionsMock)
 
+    grant_bigquery_access = MagicMock()
+    monkeypatch.setattr("functions.users.grant_bigquery_access", grant_bigquery_access)
+
     users.refresh_download_permissions()
     assert PermissionsMock.grant_iam_permissions.call_args[0][0] == user
+    assert len(grant_bigquery_access.call_args[0][0]) == 1
+    assert grant_bigquery_access.call_args[0][0][0] == "test@email.com"


### PR DESCRIPTION
## What

Updates for bigquery permission delivery, adds bigquery to permission refresh.

## Why

Enables user access to data exploration.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
