### PR TITLE
CIDC-1486 fix function call for permission update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 17 Oct 2022
+
+- `changed` API version update and fix of function name
+
+## 14 Oct 2022
+
+- `changed` API bump for protobuf versioning and functionality fix
+
+## 13 Oct 2022
+
+- `changed` API bump for bigquery permission changes
+- `added` granting bigquery permissions to download perm refresh
+
 ## 12 Oct 2022
 
 - `changed` API bump for switching staging uploader role to temp replacement

--- a/functions/users.py
+++ b/functions/users.py
@@ -43,4 +43,5 @@ def refresh_download_permissions(*args):
         )
         for user in active_users:
             print(f"Refreshing IAM download permissions for {user.email}")
-            Permissions.grant_iam_permissions(user, session=session)
+            Permissions.grant_user_permissions(user, session=session)
+        grant_bigquery_access([user.email for user in active_users])

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.5
+cidc-api-modules~=0.27.9

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -25,8 +25,10 @@ def test_refresh_download_permissions(monkeypatch):
     monkeypatch.setattr(users, "Users", UsersMock)
 
     PermissionsMock = MagicMock()
-    PermissionsMock.grant_iam_permissions = MagicMock()
+    PermissionsMock.grant_user_permissions = MagicMock()
     monkeypatch.setattr(users, "Permissions", PermissionsMock)
 
     users.refresh_download_permissions()
-    assert PermissionsMock.grant_iam_permissions.call_args[0][0] == user
+    assert PermissionsMock.grant_user_permissions.call_args[0][0] == user
+    assert len(grant_bigquery_access.call_args[0][0]) == 1
+    assert grant_bigquery_access.call_args[0][0][0] == "test@email.com"


### PR DESCRIPTION
## What

fix call to Permissions.grant_user_permissions from Permissions.grant_iam_permissions
API version push

## Why

API call not updated for permission update

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
