### PR TITLE
CIDC-1500 minimize user perms refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 31 Oct 2022
+
+- `changed` refresh just upload access for active users
+  - as object lister IAM permissions and ACL-based download permissions don't expire
+
 ## 27 Oct 2022
 
 - `changed` API/schemas bump for clinical count bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 31 Oct 2022
+## 28 Oct 2022
 
 - `changed` refresh just upload access for active users
   - as object lister IAM permissions and ACL-based download permissions don't expire

--- a/functions/users.py
+++ b/functions/users.py
@@ -1,8 +1,12 @@
 from datetime import datetime, timedelta
 from typing import List
 
-from cidc_api.models import Users, Permissions
-from cidc_api.shared.gcloud_client import send_email, grant_bigquery_access
+from cidc_api.models import Users
+from cidc_api.shared.gcloud_client import (
+    send_email,
+    grant_bigquery_access,
+    refresh_intake_access,
+)
 from cidc_api.shared.emails import CIDC_MAILING_LIST
 
 from .settings import ENV
@@ -42,6 +46,6 @@ def refresh_download_permissions(*args):
             filter_=active_today,
         )
         for user in active_users:
-            print(f"Refreshing IAM download permissions for {user.email}")
-            Permissions.grant_user_permissions(user, session=session)
+            print(f"Refreshing IAM upload permissions for {user.email}")
+            refresh_intake_access(user.email)
         grant_bigquery_access([user.email for user in active_users])

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -64,7 +64,7 @@ def test_ingest_upload(caplog, monkeypatch):
                                     "r2": {"upload_placeholder": "uuid2"},
                                 },
                             }
-                        ]
+                        ],
                     }
                 ]
             },

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -23,15 +23,14 @@ def test_refresh_download_permissions(monkeypatch):
     UsersMock = MagicMock()
     UsersMock.list.return_value = [user]
     monkeypatch.setattr(users, "Users", UsersMock)
-
-    PermissionsMock = MagicMock()
-    PermissionsMock.grant_user_permissions = MagicMock()
-    monkeypatch.setattr(users, "Permissions", PermissionsMock)
+    
+    refresh_intake_access = MagicMock()
+    monkeypatch.setattr("functions.users.refresh_intake_access", refresh_intake_access)
 
     grant_bigquery_access = MagicMock()
     monkeypatch.setattr("functions.users.grant_bigquery_access", grant_bigquery_access)
 
     users.refresh_download_permissions()
-    assert PermissionsMock.grant_user_permissions.call_args[0][0] == user
+    assert refresh_intake_access.call_args[0][0] == "test@email.com"
     assert len(grant_bigquery_access.call_args[0][0]) == 1
     assert grant_bigquery_access.call_args[0][0][0] == "test@email.com"


### PR DESCRIPTION
## What

Changed user permission refresh to just reissue upload access for active users

## Why

[CIDC-1500](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1500) Update permissions refresh in CFn -- likely cause of late night permissions error emails

## How

As object lister IAM permissions and ACL-based download permissions don't expire, those do not need to be refreshed. The only remaining call in the target function was passing through to `cidc_api.shared.gcloud_client/refresh_intake_access`

## Remarks

No way to test if this will resolve permissionsissues

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
