### PR TITLE
CIDC-1524 tighter BQ perms on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 31 Oct 2022
+
+- `changed` active user filter to check they are not disabled and approved
+- `changed` api bump: on re-enable of unapproval user, do NOT apply BQ permissions
+
 ## 28 Oct 2022
 
 - `changed` refresh just upload access for active users

--- a/functions/users.py
+++ b/functions/users.py
@@ -37,7 +37,10 @@ def refresh_download_permissions(*args):
         # Provide a 3 day window to ensure we don't miss anyone
         # if, e.g., this function fails to run on a certain day.
         Users._accessed
-        > datetime.today() - timedelta(days=3)
+        > datetime.today() - timedelta(days=3),
+        Users.disabled == False,
+        # don't grant permissions unless they've be approved
+        user.approval_date != None,
     )
     with sqlalchemy_session() as session:
         active_users = Users.list(

--- a/functions/users.py
+++ b/functions/users.py
@@ -36,8 +36,7 @@ def refresh_download_permissions(*args):
     active_today = lambda q: q.filter(
         # Provide a 3 day window to ensure we don't miss anyone
         # if, e.g., this function fails to run on a certain day.
-        Users._accessed
-        > datetime.today() - timedelta(days=3),
+        Users._accessed > datetime.today() - timedelta(days=3),
         Users.disabled == False,
         # don't grant permissions unless they've be approved
         user.approval_date != None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.16
+cidc-api-modules~=0.27.17

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -23,7 +23,7 @@ def test_refresh_download_permissions(monkeypatch):
     UsersMock = MagicMock()
     UsersMock.list.return_value = [user]
     monkeypatch.setattr(users, "Users", UsersMock)
-    
+
     refresh_intake_access = MagicMock()
     monkeypatch.setattr("functions.users.refresh_intake_access", refresh_intake_access)
 


### PR DESCRIPTION
## What

- API bump for https://github.com/CIMAC-CIDC/cidc-api-gae/pull/755
- On permissions refresh, update active user filter to require users are both not disabled and approved

## Why

[CIDC-1524](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1524) Permissions refresh in CFn -- giving bigquery to ALL users regardless of approval

## How

Add additional filter clauses.

## Remarks

- `!= None` syntax from [here](https://stackoverflow.com/questions/21784851/sqlalchemy-is-not-null-select)
- `Users.disabled == False` as in API `models/models.py`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
