### PR TITLE
CIDC-1500 deploy: updates to user permissions refreshment overnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 20 Oct 2022
+
+- `changed` API version bump for consolidation of microbiome and ctdna analysis files
+
 ## 17 Oct 2022
 
 - `changed` API version update and fix of function name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 ## 24 Oct 2022
 
-- `changed` API/schemas bump for updates biofx pipeline integration updates
+- `changed` API/schemas bump for MIBI updates
 
 ## 20 Oct 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 24 Oct 2022
+
+- `changed` API/schemas bump for updates biofx pipeline integration updates
+
 ## 20 Oct 2022
 
 - `changed` API version bump for consolidation of microbiome and ctdna analysis files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 28 Oct 2022
+
+- `changed` refresh just upload access for active users
+  - as object lister IAM permissions and ACL-based download permissions don't expire
+
 ## 27 Oct 2022
 
 - `changed` API/schemas bump for clinical count bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 31 Oct 2022
+
+- `changed` active user filter to check they are not disabled and approved
+- `changed` api bump: on re-enable of unapproval user, do NOT apply BQ permissions
+
 ## 28 Oct 2022
 
 - `changed` refresh just upload access for active users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 27 Oct 2022
+
+- `changed` API/schemas bump for clinical count bug fix
+
 ## 24 Oct 2022
 
 - `changed` API/schemas bump for MIBI updates

--- a/functions/users.py
+++ b/functions/users.py
@@ -1,8 +1,12 @@
 from datetime import datetime, timedelta
 from typing import List
 
-from cidc_api.models import Users, Permissions
-from cidc_api.shared.gcloud_client import send_email, grant_bigquery_access
+from cidc_api.models import Users
+from cidc_api.shared.gcloud_client import (
+    send_email,
+    grant_bigquery_access,
+    refresh_intake_access,
+)
 from cidc_api.shared.emails import CIDC_MAILING_LIST
 
 from .settings import ENV
@@ -42,6 +46,6 @@ def refresh_download_permissions(*args):
             filter_=active_today,
         )
         for user in active_users:
-            print(f"Refreshing IAM download permissions for {user.email}")
-            Permissions.grant_user_permissions(user, session=session)
+            print(f"Refreshing IAM upload permissions for {user.email}")
+            refresh_intake_access(user.email)
         grant_bigquery_access([user.email for user in active_users])

--- a/functions/users.py
+++ b/functions/users.py
@@ -36,8 +36,10 @@ def refresh_download_permissions(*args):
     active_today = lambda q: q.filter(
         # Provide a 3 day window to ensure we don't miss anyone
         # if, e.g., this function fails to run on a certain day.
-        Users._accessed
-        > datetime.today() - timedelta(days=3)
+        Users._accessed > datetime.today() - timedelta(days=3),
+        Users.disabled == False,
+        # don't grant permissions unless they've be approved
+        user.approval_date != None,
     )
     with sqlalchemy_session() as session:
         active_users = Users.list(

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.16
+cidc-api-modules~=0.27.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.14
+cidc-api-modules~=0.27.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.12
+cidc-api-modules~=0.27.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.15
+cidc-api-modules~=0.27.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.10
+cidc-api-modules~=0.27.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.11
+cidc-api-modules~=0.27.12

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -64,7 +64,7 @@ def test_ingest_upload(caplog, monkeypatch):
                                     "r2": {"upload_placeholder": "uuid2"},
                                 },
                             }
-                        ]
+                        ],
                     }
                 ]
             },

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -55,6 +55,7 @@ def test_ingest_upload(caplog, monkeypatch):
             "assays": {
                 "wes": [
                     {
+                        "assay_creator": "MD Anderson",
                         "records": [
                             {
                                 "cimac_id": "CIMAC-mock-sa-id",

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -23,15 +23,14 @@ def test_refresh_download_permissions(monkeypatch):
     UsersMock = MagicMock()
     UsersMock.list.return_value = [user]
     monkeypatch.setattr(users, "Users", UsersMock)
-
-    PermissionsMock = MagicMock()
-    PermissionsMock.grant_user_permissions = MagicMock()
-    monkeypatch.setattr(users, "Permissions", PermissionsMock)
+    
+    refresh_intake_access = MagicMock()
+    monkeypatch.setattr("functions.users.refresh_intake_access", refresh_intake_access)
 
     grant_bigquery_access = MagicMock()
     monkeypatch.setattr("functions.users.grant_bigquery_access", grant_bigquery_access)
 
     users.refresh_download_permissions()
-    assert PermissionsMock.grant_user_permissions.call_args[0][0] == user
+    assert refresh_intake_access.call_args[0][0] == "test@email.com"
     assert len(grant_bigquery_access.call_args[0][0]) == 1
     assert grant_bigquery_access.call_args[0][0][0] == "test@email.com"

--- a/tests/functions/test_users.py
+++ b/tests/functions/test_users.py
@@ -23,7 +23,7 @@ def test_refresh_download_permissions(monkeypatch):
     UsersMock = MagicMock()
     UsersMock.list.return_value = [user]
     monkeypatch.setattr(users, "Users", UsersMock)
-    
+
     refresh_intake_access = MagicMock()
     monkeypatch.setattr("functions.users.refresh_intake_access", refresh_intake_access)
 


### PR DESCRIPTION
Deploys:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/406
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/407

## What

- Changed user permission refresh to just reissue upload access for active users
- On permissions refresh, update active user filter to require users are both not disabled and approved

## Why

- [CIDC-1500](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1500) Update permissions refresh in CFn -- likely cause of late night permissions error emails
- [CIDC-1524](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1524) Permissions refresh in CFn -- giving bigquery to ALL users regardless of approval

## How

- As object lister IAM permissions and ACL-based download permissions don't expire, those do not need to be refreshed. The only remaining call in the target function was passing through to `cidc_api.shared.gcloud_client/refresh_intake_access`
- Add additional filter clauses.

## Remarks

- No way to test if this will resolve permissions issues
- `!= None` syntax from [here](https://stackoverflow.com/questions/21784851/sqlalchemy-is-not-null-select)
- `Users.disabled == False` as in API `models/models.py`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
