### PR TITLE
CIDC-876 change file derivation: don't error when not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 8 Nov 2022
+## 10 Nov 2022
+
+- `changed` API/schemas bump and handling for null return when there's no file derivation
+
+## 08 Nov 2022
 
 - `changed` API/schemas bump for adding batch to meta.csv for TCR
 
@@ -17,7 +21,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 - `changed` api/schemas bump: new front-page counting
 
-## 3 Nov 2022
+## 03 Nov 2022
 
 - `changed` API/schemas bump for adding meta.csv to TCR config returns, update local file path description
 

--- a/functions/util.py
+++ b/functions/util.py
@@ -50,7 +50,7 @@ def sqlalchemy_session():
         session.close()
 
 
-def extract_pubsub_data(event: dict):
+def extract_pubsub_data(event: dict) -> str:
     """Pull out and decode data from a pub/sub event."""
     # Pub/sub event data is base64-encoded
     b64data = event["data"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.20
+cidc-api-modules~=0.27.21


### PR DESCRIPTION
## What

- API/schemas bump to change file derivation to return None instead of erroring when not defined
- handle null return and gracefully exit

## Why

- [CIDC-876](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-876) derive_files_from_... cloud functions throw errors when no derivation is implemented

## How

if returned None, print note and exit successfully

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
