### PR TITLE
CIDC-1552 api/schemas bump: remove analysis from wes folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 28 Nov 2022
+
+- `changed` API/schemas bump for WES analysis template folder update
+
 ## 17 Nov 2022
 
 - `changed` API/schemas bump for wes bait set swap

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.22
+cidc-api-modules~=0.27.23


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/568

## What

API/Schemas bump to remove `analysis` from end of WES analysis folder in autogenerated templates

## Why

[CIDC-1552](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1552)

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
