### PR TITLE
CIDC-1554 remove separate biofx permissioning

### DIFF
--- a/.env
+++ b/.env
@@ -36,5 +36,3 @@ AUTH0_DOMAIN='https://cidc-test.auth0.com'
 AUTH0_CLIENT_ID='Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD'
 
 ENV="dev"
-
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT="{\"wes\":\"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu\", \"rna\":\"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu\"}"

--- a/.env.prod.yaml
+++ b/.env.prod.yaml
@@ -20,6 +20,5 @@ GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
 GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
 GOOGLE_WORKER_TOPIC: "worker"
 
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"
 GOOGLE_EPHEMERAL_BUCKET: "cidc-ephemeral-prod"

--- a/.env.staging.yaml
+++ b/.env.staging.yaml
@@ -16,7 +16,6 @@ GOOGLE_LOGS_BUCKET: "cidc-logs-export-staging"
 GOOGLE_EMAILS_TOPIC: "emails"
 GOOGLE_CLOUD_PROJECT: "cidc-dfci-staging"
 GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT: '{"wes":"staging-cidc-dfci-biofx-wes@ds.dfci.harvard.edu", "rna":"staging-cidc-dfci-biofx-rna@ds.dfci.harvard.edu"}'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC: "assay_or_analysis_upload_complete"
 GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `removed` permissioning of biofx groups in ingest_upload
   - separate from main permissions system in API
   - making concurrent updates to the same files via grant_download_permissions_for_upload_job
+- `removed` unused is_group option in granting permissions
+  - was only used by the above now-removed permissioning system
 
 ## 28 Nov 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 30 Nov 2022
+
+- `removed` permissioning of biofx groups in ingest_upload
+  - separate from main permissions system in API
+  - making concurrent updates to the same files via grant_download_permissions_for_upload_job
+
 ## 28 Nov 2022
 
 - `changed` API/schemas bump for WES analysis template folder update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This Changelog tracks changes to this project. The notes below include a summary
   - making concurrent updates to the same files via grant_download_permissions_for_upload_job
 - `removed` unused is_group option in granting permissions
   - was only used by the above now-removed permissioning system
+- `changed` API bump for parallel removal of is_group
 
 ## 28 Nov 2022
 

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -43,8 +43,6 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
     user_email_list: List[str]
         a comma separated list of user emails to apply the permissions for
         otherwise loaded from the database for all affected users
-    is_group: bool = False
-        whether to use blob.acl.group instead of blob.acl.user
     """
     try:
         # this returns the str, then convert it to a dict
@@ -66,7 +64,6 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
         # don't grab the trial_id and upload_type from the data here to keep references clear below
 
         revoke = data.get("revoke", False)
-        is_group = data.get("is_group", False)
 
         with sqlalchemy_session() as session:
             try:
@@ -113,7 +110,6 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
                                 "user_email_list": user_email_list,
                                 "blob_name_list": chunk,
                                 "revoke": revoke,
-                                "is_group": is_group,
                             }
 
                             report = _encode_and_publish(
@@ -137,7 +133,6 @@ def permissions_worker(
     user_email_list: List[str] = [],
     blob_name_list: List[str] = [],
     revoke: bool = False,
-    is_group: bool = False,
 ):
     if not user_email_list or not blob_name_list:
         data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}
@@ -150,13 +145,11 @@ def permissions_worker(
             revoke_download_access_from_blob_names(
                 user_email_list=user_email_list,
                 blob_name_list=blob_name_list,
-                is_group=is_group,
             )
         else:
             grant_download_access_to_blob_names(
                 user_email_list=user_email_list,
                 blob_name_list=blob_name_list,
-                is_group=is_group,
             )
     except Exception as e:
         data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}

--- a/functions/settings.py
+++ b/functions/settings.py
@@ -1,6 +1,5 @@
 """Configuration for CIDC functions."""
 import os
-import json
 
 # Cloud Functions provide the current GCP project id
 # in the environment variable GCP_PROJECT. If this
@@ -29,9 +28,6 @@ GOOGLE_UPLOAD_BUCKET = os.environ.get("GOOGLE_UPLOAD_BUCKET")
 GOOGLE_ACL_DATA_BUCKET = os.environ.get("GOOGLE_ACL_DATA_BUCKET")
 GOOGLE_LOGS_BUCKET = os.environ.get("GOOGLE_LOGS_BUCKET")
 GOOGLE_ANALYSIS_GROUP_ROLE = f"projects/{GCP_PROJECT}/roles/CIDC_biofx"
-GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT = json.loads(
-    os.environ.get("GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT", "{}")
-)
 GOOGLE_ANALYSIS_PERMISSIONS_GRANT_FOR_DAYS = 60
 GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC = os.environ.get(
     "GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.23
+cidc-api-modules~=0.27.24

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -90,7 +90,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[:1],
                     "blob_name_list": mock_blob_name_list.return_value[:100],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -102,7 +101,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[:1],
                     "blob_name_list": mock_blob_name_list.return_value[100:],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -114,7 +112,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[1:2],
                     "blob_name_list": mock_blob_name_list.return_value[:100],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -126,7 +123,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[1:2],
                     "blob_name_list": mock_blob_name_list.return_value[100:],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -138,7 +134,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[-1:],
                     "blob_name_list": mock_blob_name_list.return_value[:100],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -150,7 +145,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list[-1:],
                     "blob_name_list": mock_blob_name_list.return_value[100:],
                     "revoke": False,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -195,7 +189,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list,
                     "blob_name_list": mock_blob_name_list.return_value[:100],
                     "revoke": True,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -207,7 +200,6 @@ def test_grant_download_permissions(monkeypatch):
                     "user_email_list": user_email_list,
                     "blob_name_list": mock_blob_name_list.return_value[100:],
                     "revoke": True,
-                    "is_group": False,
                 }
             ),
             GOOGLE_WORKER_TOPIC,
@@ -237,10 +229,10 @@ def test_permissions_worker(monkeypatch):
         user_email_list=user_email_list,
         blob_name_list=blob_name_list,
         revoke=False,
-        is_group=False,
     )
     mock_grant.assert_called_with(
-        user_email_list=user_email_list, blob_name_list=blob_name_list, is_group=False
+        user_email_list=user_email_list,
+        blob_name_list=blob_name_list,
     )
     mock_revoke.assert_not_called()
 
@@ -249,9 +241,9 @@ def test_permissions_worker(monkeypatch):
         user_email_list=user_email_list,
         blob_name_list=blob_name_list,
         revoke=True,
-        is_group=False,
     )
     mock_grant.assert_not_called()
     mock_revoke.assert_called_with(
-        user_email_list=user_email_list, blob_name_list=blob_name_list, is_group=False
+        user_email_list=user_email_list,
+        blob_name_list=blob_name_list,
     )

--- a/tests/functions/test_uploads.py
+++ b/tests/functions/test_uploads.py
@@ -17,7 +17,6 @@ from functions.uploads import ingest_upload, saved_failure_status
 from functions.settings import (
     GOOGLE_ACL_DATA_BUCKET,
     GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC,
-    GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC,
 )
 
 from tests.util import make_pubsub_event, with_app_context
@@ -95,11 +94,6 @@ def test_ingest_upload(caplog, monkeypatch):
     xlsx_blob = MagicMock()
     _get_bucket_and_blob.return_value = None, xlsx_blob
     monkeypatch.setattr("functions.uploads._get_bucket_and_blob", _get_bucket_and_blob)
-
-    monkeypatch.setattr(
-        "functions.uploads.GOOGLE_ANALYSIS_PERMISSIONS_GROUPS_DICT",
-        {"wes": "analysis-group@email"},
-    )
 
     # mocking `google.cloud.storage.Client()` to not actually create a client
     _storage_client = MagicMock("_storage_client")
@@ -191,17 +185,6 @@ def test_ingest_upload(caplog, monkeypatch):
 
     # Check that triggered downstream processing and biofx permisssions assignment
     expected_calls = [
-        call(
-            str(
-                {
-                    "trial_id": TRIAL_ID,
-                    "upload_type": job.upload_type,
-                    "user_email_list": ["analysis-group@email"],
-                    "is_group": True,
-                }
-            ),
-            GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC,
-        ),
         call(str(job.id), GOOGLE_ASSAY_OR_ANALYSIS_UPLOAD_TOPIC),
     ]
     assert all(


### PR DESCRIPTION
## What

Remove separate permissioning system for biofx groups in ingest_upload.
Also remove unused `is_group` option in granting permissions functions, as it was only used by the above.
API bump for related removal of `is_group` option in granting/revoking permissions functions in the API, as it was only used by the above.

## Why

- separate from main permissions system in API
- making concurrent updates to the same files via grant_download_permissions_for_upload_job leading to dev alert email
  - [CIDC-1554](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1554) Check in dev alerts for permissions and what is triggering them

## How

Remove permissioning code and related constant pulled from the environment.
Remove `is_group` option and related code from `grant_download_permissions` and `permissions_worker`.
API bump.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
