### PR TITLE
CIDC-1554 allow list of uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 02 Dec 2022
+
+- `changed` API/schemas bump for updated permissions handling
+- `changed` download permissions handling to accept list of upload_types
+
 ## 01 Dec 2022
 
 - `changed` API/schemas bump for dateparser version update

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.25
+cidc-api-modules~=0.27.26

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -2,6 +2,7 @@ import functions.grant_permissions
 from functions.grant_permissions import grant_download_permissions, permissions_worker
 from functions.settings import GOOGLE_WORKER_TOPIC
 import pytest
+from typing import List, Optional, Union
 from unittest.mock import MagicMock, call
 
 
@@ -10,16 +11,30 @@ def test_grant_download_permissions(monkeypatch):
     user_email_list = ["foo@bar.com", "user@test.com", "cidc@foo.bar"]
     full_email_dict = {
         None: {"bar": [user_email_list[0]]},
-        "foo": {None: [user_email_list[1]], "bar": [user_email_list[2]]},
+        "foo": {
+            None: [user_email_list[1]],
+            "bar": [user_email_list[2]],
+            "baz": [user_email_list[2]],
+        },
         "biz": {"wes": [user_email_list[2]]},
     }
 
-    def mock_get_user_emails(trial_id: str, upload_type: str, session):
+    def mock_get_user_emails(
+        trial_id: Optional[str], upload_type: Optional[Union[str, List[str]]], session
+    ):
+        def upload_matches(this_upload: Optional[str]):
+            if this_upload is None:
+                return True
+            if isinstance(upload_type, str):
+                return this_upload == upload_type
+            else:
+                return this_upload in upload_type
+
         return {
             trial: {
                 upload: users
                 for upload, users in upload_dict.items()
-                if upload is None or upload == upload_type
+                if upload_matches(upload)
             }
             for trial, upload_dict in full_email_dict.items()
             if trial is None or trial == trial_id
@@ -33,7 +48,7 @@ def test_grant_download_permissions(monkeypatch):
 
     mock_blob_name_list = MagicMock()
     # need more than 100 to test chunking
-    mock_blob_name_list.return_value = [f"blob{n}" for n in range(100 + 50)]
+    mock_blob_name_list.return_value = set([f"blob{n}" for n in range(100 + 50)])
     monkeypatch.setattr(
         functions.grant_permissions, "get_blob_names", mock_blob_name_list
     )
@@ -88,7 +103,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[:1],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -99,7 +114,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[:1],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -110,7 +125,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[1:2],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -121,7 +136,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[1:2],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -132,7 +147,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[-1:],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -143,7 +158,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[-1:],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -168,7 +183,7 @@ def test_grant_download_permissions(monkeypatch):
     mock_extract_data.return_value = str(
         {
             "trial_id": "foo",
-            "upload_type": "bar",
+            "upload_type": ["bar", "baz"],
             "user_email_list": user_email_list,
             "revoke": True,
         }
@@ -178,7 +193,7 @@ def test_grant_download_permissions(monkeypatch):
     assert mock_blob_name_list.call_count == 1
     _, kwargs = mock_blob_name_list.call_args
     assert kwargs["trial_id"] == "foo"
-    assert kwargs["upload_type"] == "bar"
+    assert kwargs["upload_type"] == ("bar", "baz")
 
     assert mock_encode_and_publish.call_count == 2
     assert mock_encode_and_publish.call_args_list == [
@@ -187,7 +202,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list,
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": True,
                 }
             ),
@@ -198,7 +213,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list,
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": True,
                 }
             ),


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/570
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/773

## What

API/schemas bump for updated permissions handling
Changed download permissions handling to accept list of `upload_type`s

## Why

[CIDC-1554](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1554) Check in dev alerts for permissions and what is triggering them
When two individual assay permissions for same trial share a prefix, tries to update same file twice at the same time on dis/en-activate.

## How

- Also allow `List[str]` instead of just `Optional[str]` for `upload_type` in target functions
- Convert blob names from `set` to `list` for chunking

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
