### PR TITLE
CIDC-1554 PROD DEPLOY: allow list of uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 02 Dec 2022
-
-- `changed` API/schemas bump for updated permissions handling
-- `changed` download permissions handling to accept list of upload_types
-
 ## 01 Dec 2022
 
 - `changed` API/schemas bump for dateparser version update

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import logging
 import sys
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional
 
 from .settings import ENV, GOOGLE_WORKER_TOPIC
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
@@ -33,10 +33,8 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
     ----------
     trial_id: Optional[str]
         the trial_id for the trial to affect
-        explicitly pass None for cross-trial
-    upload_type: Optional[Union[str, List[str]]]
+    upload_type: Optional[str]
         the upload_type, as stored in the Permissions table
-        explicitly pass None for cross-assay (excludes clinical_data)
 
     Optional Parameters
     -------------------
@@ -63,25 +61,24 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
             raise Exception(
                 f"trial_id and upload_type must both be provided, you provided: {data}\nProvide None for cross-trial/assay matching"
             )
+        # don't grab the trial_id and upload_type from the data here to keep references clear below
 
         revoke = data.get("revoke", False)
-        trial_id: Optional[str] = data.get("trial_id")
-        upload_type: Optional[Union[str, List[str]]] = data.get("upload_type")
-        if upload_type:
-            if isinstance(upload_type, str):
-                upload_type: Optional[List[str]] = [upload_type]
-            upload_type: Optional[Tuple[str]] = tuple(upload_type)
 
         with sqlalchemy_session() as session:
             try:
                 if "user_email_list" in data:
                     user_email_dict: Dict[
-                        Optional[str], Dict[Optional[Tuple[str]], List[str]]
-                    ] = {trial_id: {upload_type: data["user_email_list"]}}
+                        Optional[str], Dict[Optional[str], List[str]]
+                    ] = {
+                        data.get("trial_id"): {
+                            data.get("upload_type"): data["user_email_list"]
+                        }
+                    }
 
                 else:
                     user_email_dict: Dict[
-                        Optional[str], Dict[Optional[str], List[str]]
+                        str, Dict[str, List[str]]
                     ] = Permissions.get_user_emails_for_trial_upload(
                         trial_id=data.get("trial_id"),
                         upload_type=data.get("upload_type"),
@@ -90,10 +87,8 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
 
                 blob_name_dict: Dict[str, Dict[str, List[str]]] = {
                     trial: {
-                        upload: list(
-                            get_blob_names(
-                                trial_id=trial, upload_type=upload, session=session
-                            )
+                        upload: get_blob_names(
+                            trial_id=trial, upload_type=upload, session=session
                         )
                         for upload in upload_dict.keys()
                     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.26
+cidc-api-modules~=0.27.25


### PR DESCRIPTION
Deploys
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/420
Parallels
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/775

## What

API/schemas bump for updated permissions handling
Changed download permissions handling to accept list of `upload_type`s

## Why

[CIDC-1554](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1554) Check in dev alerts for permissions and what is triggering them
When two individual assay permissions for same trial share a prefix, tries to update same file twice at the same time on dis/en-activate.

## How

- Also allow `List[str]` instead of just `Optional[str]` for `upload_type` in target functions
- Convert blob names from `set` to `list` for chunking

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
