### PR TITLE
CIDC-1588 api bump, safe emails/blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 28 Dec 2022
+
+- `changed` API bump to
+  - deduplicate blobs in revoke
+  - fix blob prefix generation error on uploads without files
+- `fixed` don't error if no users or blobs to apply
+
 ## 27 Dec 2022
 
 - `changed` API/schemas bump to add urine to manifests' type of sample

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -102,7 +102,12 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
 
                 for trial_id, upload_dict in blob_name_dict.items():
                     for upload_type, blob_name_list in upload_dict.items():
-                        user_email_list = user_email_dict[trial_id][upload_type]
+                        user_email_list: List[str] = user_email_dict.get(
+                            trial_id, {}
+                        ).get(upload_type, [])
+
+                        if not user_email_list or not blob_name_list:
+                            continue
 
                         blob_name_list_chunks = [
                             blob_name_list[i : i + BLOBS_PER_CHUNK]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.29
+cidc-api-modules~=0.27.30


### PR DESCRIPTION
Parallels https://github.com/CIMAC-CIDC/cidc-api-gae/pull/782

## What

- API bump to
  - deduplicate blobs in revoke
  - fix blob prefix generation error on uploads without files
- Fix error if no users or blobs to apply permissions to

## Why

[CIDC-1588](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1588)
- error on autodisable when overlapping prefixes were not deduplicated, causing collisions
- `KeyError` on manifests, which have no file prefix and so no entry in schemas prefix dict
- preemptively prevent more `KeyError`s that shouldn't be reachable

## How

- use `.get()` on trial/upload `dict` in case of missing keys
- check user emails and blobs in case of empty lists

## Remarks

these errors should NOT be reachable

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
