### PR TITLE
CIDC-1601 api/schemas bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 3 Jan 2023
+## 05 Jan 2023
+
+- `changed` API/schemas bump to fix samples/participants prefix for file permissioning
+
+## 03 Jan 2023
 
 - `changed` API bump to not issue new permissions if user is disabled or not approved
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.31
+cidc-api-modules~=0.27.32


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/574
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/784

## What

Schemas bump to fix bug in samples/participants prefix for file permissioning

## Why

[CIDC-1601](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1601)
- Noticed by Essex @crouchcd 
- Trailing `/` means would apply to any subdirectories, not the files that we want

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
