### PR TITLE
CIDC-1608 manifest permission fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 17 Jan 2023
+
+- `changed` API bump for permission triggering for participants and samples info on upload
+- `fixed` when ingesting derived manifest files mark upload type correctly
+
 ## 05 Jan 2023
 
 - `changed` API/schemas bump to fix samples/participants prefix for file permissioning

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -74,7 +74,7 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
 
         with sqlalchemy_session() as session:
             try:
-                if data.get("user_email_list") is []:
+                if data.get("user_email_list"):
                     user_email_dict: Dict[
                         Optional[str], Dict[Optional[Tuple[str]], List[str]]
                     ] = {trial_id: {upload_type: data["user_email_list"]}}

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -74,7 +74,7 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
 
         with sqlalchemy_session() as session:
             try:
-                if "user_email_list" in data:
+                if data.get("user_email_list") is []:
                     user_email_dict: Dict[
                         Optional[str], Dict[Optional[Tuple[str]], List[str]]
                     ] = {trial_id: {upload_type: data["user_email_list"]}}

--- a/functions/upload_postprocessing.py
+++ b/functions/upload_postprocessing.py
@@ -102,10 +102,14 @@ def _derive_files_from_upload(trial_id: str, upload_type: str, upload_id: str, s
         # Build basic facet group
         facet_group = f"{artifact.data_format}|{artifact.file_type}"
 
+        file_upload_type = upload_type
+        if artifact.file_type in ("participants info", "samples info"):
+            file_upload_type = artifact.file_type
+
         # Save to database
         df_record = DownloadableFiles.create_from_blob(
             trial_id=trial_record.trial_id,
-            upload_type=upload_type,
+            upload_type=file_upload_type,
             data_format=artifact.data_format,
             facet_group=facet_group,
             blob=blob,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.32
+cidc-api-modules~=0.27.33


### PR DESCRIPTION
## What

- `changed` API bump for permission triggering for participants and samples info on upload
- `fixed` when ingesting derived manifest files mark upload type correctly

## Why

Manifest derived file permissions were not getting delivered correctly

## How

If manifest derived files (participants or samples info) files are being added to database correctly mark upload type

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
