### PR TITLE
CIDC-1608 Prod Deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 27 Dec 2022
+
+- `changed` API/schemas bump to add urine to manifests' type of sample
+
 ## 20 Dec 2022
 
 - `changed` API/schemas bump to remove ATACseq analysis batch report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 02 Dec 2022
+
+- `changed` API/schemas bump for updated permissions handling
+- `changed` download permissions handling to accept list of upload_types
+
 ## 01 Dec 2022
 
 - `changed` API/schemas bump for dateparser version update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 02 Dec 2022
-
-- `changed` API/schemas bump for updated permissions handling
-- `changed` download permissions handling to accept list of upload_types
-
 ## 01 Dec 2022
 
 - `changed` API/schemas bump for dateparser version update

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import logging
 import sys
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional
 
 from .settings import ENV, GOOGLE_WORKER_TOPIC
 from .util import BackgroundContext, extract_pubsub_data, sqlalchemy_session
@@ -33,10 +33,8 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
     ----------
     trial_id: Optional[str]
         the trial_id for the trial to affect
-        explicitly pass None for cross-trial
-    upload_type: Optional[Union[str, List[str]]]
+    upload_type: Optional[str]
         the upload_type, as stored in the Permissions table
-        explicitly pass None for cross-assay (excludes clinical_data)
 
     Optional Parameters
     -------------------
@@ -63,25 +61,24 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
             raise Exception(
                 f"trial_id and upload_type must both be provided, you provided: {data}\nProvide None for cross-trial/assay matching"
             )
+        # don't grab the trial_id and upload_type from the data here to keep references clear below
 
         revoke = data.get("revoke", False)
-        trial_id: Optional[str] = data.get("trial_id")
-        upload_type: Optional[Union[str, List[str]]] = data.get("upload_type")
-        if upload_type:
-            if isinstance(upload_type, str):
-                upload_type: Optional[List[str]] = [upload_type]
-            upload_type: Optional[Tuple[str]] = tuple(upload_type)
 
         with sqlalchemy_session() as session:
             try:
                 if "user_email_list" in data:
                     user_email_dict: Dict[
-                        Optional[str], Dict[Optional[Tuple[str]], List[str]]
-                    ] = {trial_id: {upload_type: data["user_email_list"]}}
+                        Optional[str], Dict[Optional[str], List[str]]
+                    ] = {
+                        data.get("trial_id"): {
+                            data.get("upload_type"): data["user_email_list"]
+                        }
+                    }
 
                 else:
                     user_email_dict: Dict[
-                        Optional[str], Dict[Optional[str], List[str]]
+                        str, Dict[str, List[str]]
                     ] = Permissions.get_user_emails_for_trial_upload(
                         trial_id=data.get("trial_id"),
                         upload_type=data.get("upload_type"),
@@ -90,10 +87,8 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
 
                 blob_name_dict: Dict[str, Dict[str, List[str]]] = {
                     trial: {
-                        upload: list(
-                            get_blob_names(
-                                trial_id=trial, upload_type=upload, session=session
-                            )
+                        upload: get_blob_names(
+                            trial_id=trial, upload_type=upload, session=session
                         )
                         for upload in upload_dict.keys()
                     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.28
+cidc-api-modules~=0.27.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.26
+cidc-api-modules~=0.27.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.25
+cidc-api-modules~=0.27.26

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -2,6 +2,7 @@ import functions.grant_permissions
 from functions.grant_permissions import grant_download_permissions, permissions_worker
 from functions.settings import GOOGLE_WORKER_TOPIC
 import pytest
+from typing import List, Optional, Union
 from unittest.mock import MagicMock, call
 
 
@@ -10,16 +11,30 @@ def test_grant_download_permissions(monkeypatch):
     user_email_list = ["foo@bar.com", "user@test.com", "cidc@foo.bar"]
     full_email_dict = {
         None: {"bar": [user_email_list[0]]},
-        "foo": {None: [user_email_list[1]], "bar": [user_email_list[2]]},
+        "foo": {
+            None: [user_email_list[1]],
+            "bar": [user_email_list[2]],
+            "baz": [user_email_list[2]],
+        },
         "biz": {"wes": [user_email_list[2]]},
     }
 
-    def mock_get_user_emails(trial_id: str, upload_type: str, session):
+    def mock_get_user_emails(
+        trial_id: Optional[str], upload_type: Optional[Union[str, List[str]]], session
+    ):
+        def upload_matches(this_upload: Optional[str]):
+            if this_upload is None:
+                return True
+            if isinstance(upload_type, str):
+                return this_upload == upload_type
+            else:
+                return this_upload in upload_type
+
         return {
             trial: {
                 upload: users
                 for upload, users in upload_dict.items()
-                if upload is None or upload == upload_type
+                if upload_matches(upload)
             }
             for trial, upload_dict in full_email_dict.items()
             if trial is None or trial == trial_id
@@ -33,7 +48,7 @@ def test_grant_download_permissions(monkeypatch):
 
     mock_blob_name_list = MagicMock()
     # need more than 100 to test chunking
-    mock_blob_name_list.return_value = [f"blob{n}" for n in range(100 + 50)]
+    mock_blob_name_list.return_value = set([f"blob{n}" for n in range(100 + 50)])
     monkeypatch.setattr(
         functions.grant_permissions, "get_blob_names", mock_blob_name_list
     )
@@ -88,7 +103,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[:1],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -99,7 +114,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[:1],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -110,7 +125,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[1:2],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -121,7 +136,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[1:2],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -132,7 +147,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[-1:],
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": False,
                 }
             ),
@@ -143,7 +158,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list[-1:],
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": False,
                 }
             ),
@@ -168,7 +183,7 @@ def test_grant_download_permissions(monkeypatch):
     mock_extract_data.return_value = str(
         {
             "trial_id": "foo",
-            "upload_type": "bar",
+            "upload_type": ["bar", "baz"],
             "user_email_list": user_email_list,
             "revoke": True,
         }
@@ -178,7 +193,7 @@ def test_grant_download_permissions(monkeypatch):
     assert mock_blob_name_list.call_count == 1
     _, kwargs = mock_blob_name_list.call_args
     assert kwargs["trial_id"] == "foo"
-    assert kwargs["upload_type"] == "bar"
+    assert kwargs["upload_type"] == ("bar", "baz")
 
     assert mock_encode_and_publish.call_count == 2
     assert mock_encode_and_publish.call_args_list == [
@@ -187,7 +202,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list,
-                    "blob_name_list": mock_blob_name_list.return_value[:100],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[:100],
                     "revoke": True,
                 }
             ),
@@ -198,7 +213,7 @@ def test_grant_download_permissions(monkeypatch):
                 {
                     "_fn": "permissions_worker",
                     "user_email_list": user_email_list,
-                    "blob_name_list": mock_blob_name_list.return_value[100:],
+                    "blob_name_list": list(mock_blob_name_list.return_value)[100:],
                     "revoke": True,
                 }
             ),


### PR DESCRIPTION
## What

changed API bump for permission triggering for participants and samples info on upload
fixed when ingesting derived manifest files mark upload type correctly

## Why

Manifest derived file permissions were not getting delivered correctly

## How

If manifest derived files (participants or samples info) files are being added to database correctly mark upload type
added triggering for permissions on manifest upload

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
