### PR TITLE
CIDC-1619 bump API for perm tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 02 Feb 2023
+
+- `changed` API bump for permission tweak
+
 ## 23 Jan 2023
 
 - `changed` added trigger to file permissioning on manifest derived file creation

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.33
+cidc-api-modules~=0.27.34


### PR DESCRIPTION
## What

Bump API for permissions tweak

## Why

Recent extra calls to permission granting on manifests have caused demo alert triggers, so removal of any unneeded calls will hopefully prevent this

## How

Only call upload_type permission grants on non-manifest uploads. Don't do any permission delivery on tumor_only_pairing ingestion

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
