### PR TITLE
Remove dev alert email on permissions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 08 Feb 2023
+
+- `removed` sending of dev alert email on permissions error
+
 ## 02 Feb 2023
 
 - `changed` API bump for permission tweak

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -164,9 +164,9 @@ def permissions_worker(
     except Exception as e:
         data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}
         logger.error(f"Error on {data}:\nError:{e}", exc_info=True)
-        send_email(
-            CIDC_MAILING_LIST,
-            f"[DEV ALERT]({ENV}) Error granting permissions: {datetime.now()}",
-            html_content=f"See logs for more info.<br />{e}<br /> For: {data}",
-        )
+        # send_email(
+        #     CIDC_MAILING_LIST,
+        #     f"[DEV ALERT]({ENV}) Error granting permissions: {datetime.now()}",
+        #     html_content=f"See logs for more info.<br />{e}<br /> For: {data}",
+        # )
         raise e


### PR DESCRIPTION
## What

Remove sending of dev alert email on permissions error

## Why

They haven't been too useful

## How

Comment out

## Remarks

Still marked in the logs

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
