### PR TITLE
CIDC-1637 DEPLOY bump to fix cross-assay perms bug, clean up permissions function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 08 Feb 2023
+
+- `removed` sending of dev alert email on permissions error
+
 ## 02 Feb 2023
 
 - `changed` API bump for permission tweak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 24 Feb 2023
+
+- `changed` API bump for permissions bug fix
+- `changed` better typing and variable handling in grant_permissions function
+
 ## 08 Feb 2023
 
 - `removed` sending of dev alert email on permissions error

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -164,9 +164,9 @@ def permissions_worker(
     except Exception as e:
         data = {"user_email_list": user_email_list, "blob_name_list": blob_name_list}
         logger.error(f"Error on {data}:\nError:{e}", exc_info=True)
-        send_email(
-            CIDC_MAILING_LIST,
-            f"[DEV ALERT]({ENV}) Error granting permissions: {datetime.now()}",
-            html_content=f"See logs for more info.<br />{e}<br /> For: {data}",
-        )
+        # send_email(
+        #     CIDC_MAILING_LIST,
+        #     f"[DEV ALERT]({ENV}) Error granting permissions: {datetime.now()}",
+        #     html_content=f"See logs for more info.<br />{e}<br /> For: {data}",
+        # )
         raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ matplotlib==3.4.1
 statsmodels==0.12.2
 scikit_learn==0.24.2
 
-cidc-api-modules~=0.27.34
+cidc-api-modules~=0.27.37


### PR DESCRIPTION
Parallels:
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/796
Deploys:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/439

Parallels
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/795

## What

- API bug: Fix permission error where cross-assay single-trial permissions weren't granted/revoked on user (de)activate
- Better typing and variable handling in `grant_permissions` function for clarity in future maintenance

## Why

Discovered in testing related to [CIDC-1637](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1637) Clean up production resources and test

## How

- API bump
- Use separate variables when converting user input to a new type eg `raw_data` and `raw_upload_type`
- Add clearer typing hints

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
