### PR TITLE
CIDC-1679 fix type bug causing error on cloud issuing of cross-trial permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 20 Mar 2023
+
+- `fixed` bug causing error on cloud issuing of cross-trial permissions
+  - this is interaction with accepted param types from API, so would need integrative testing
+
 ## 24 Feb 2023
 
 - `changed` API bump for permissions bug fix

--- a/functions/grant_permissions.py
+++ b/functions/grant_permissions.py
@@ -67,15 +67,13 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
         revoke = data.get("revoke", False)
         trial_id: Optional[str] = data.get("trial_id")
 
-        upload_type: Optional[Tuple[str]] = None  # this None will always be replaced
+        upload_type: Optional[Tuple[str]] = None
         raw_upload_type: Optional[Union[str, List[str]]] = data.get("upload_type")
         if raw_upload_type:
             if isinstance(raw_upload_type, str):
                 upload_type = (raw_upload_type,)
             else:
                 upload_type = tuple(raw_upload_type)
-        else:
-            upload_dict = raw_upload_type  # type: ignore
 
         with sqlalchemy_session() as session:
             user_email_dict: Dict[
@@ -98,7 +96,11 @@ def grant_download_permissions(event: dict, context: BackgroundContext):
                     trial: {
                         upload: list(
                             get_blob_names(
-                                trial_id=trial, upload_type=upload, session=session
+                                trial_id=trial,
+                                upload_type=(upload,)
+                                if isinstance(upload, str)
+                                else upload,
+                                session=session,
                             )
                         )
                         for upload in upload_dict.keys()

--- a/tests/functions/test_grant_permissions.py
+++ b/tests/functions/test_grant_permissions.py
@@ -53,14 +53,15 @@ def test_grant_download_permissions(monkeypatch):
     mock_blob_name_list.return_value = set([f"blob{n}" for n in range(100 + 50)])
 
     def mock_blob_list(
-        trial_id: Optional[str], upload_type: Optional[Tuple[Optional[str]]], **_
+        trial_id: Optional[str], upload_type: Optional[Tuple[Optional[str]]], **kwargs
     ) -> Set[str]:
+        """Type check and then pass through to the mock"""
         assert trial_id is None or isinstance(trial_id, str), type(trial_id)
-        assert trial_id is None or (
+        assert upload_type is None or (
             isinstance(upload_type, tuple)
-            and all(isinstance(u, str) for u in upload_type)
+            and all([isinstance(u, str) for u in upload_type])
         ), type(upload_type)
-        return mock_blob_name_list()
+        return mock_blob_name_list(trial_id=trial_id, upload_type=upload_type, **kwargs)
 
     monkeypatch.setattr(functions.grant_permissions, "get_blob_names", mock_blob_list)
 
@@ -105,7 +106,7 @@ def test_grant_download_permissions(monkeypatch):
     # Note no (biz, wes) as that doesn't match
     for _, kwargs in mock_blob_name_list.call_args_list:
         assert kwargs["trial_id"] in (None, "foo")
-        assert kwargs["upload_type"] in (None, "bar")
+        assert kwargs["upload_type"] in (None, ("bar",))
 
     assert mock_encode_and_publish.call_count == 6
     assert mock_encode_and_publish.call_args_list == [


### PR DESCRIPTION
## What

Fix bug causing error on cloud issuing of cross-trial permissions
This is interaction with accepted param types from API, so would need integrative testing

## Why

Discovered in staging testing

## How

Extend test to check param types for this function

## Remarks

Test here needs to be changed if the underlying API function changes

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
