### PR TITLE
raise FileNotFoundError if blob doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 18 Apr 2023
+
+- `fixed` `_download_blob_bytes` should raise FileNotFoundError if the blob to download doesn't exist
+
 ## 24 Feb 2023
 
 - `changed` API bump for permissions bug fix

--- a/functions/util.py
+++ b/functions/util.py
@@ -90,7 +90,7 @@ def _download_blob_bytes(object_name: str) -> bytes:
     bucket = storage_client.get_bucket(GOOGLE_ACL_DATA_BUCKET)
     blob = bucket.get_blob(object_name)
     if not blob:
-        FileNotFoundError(
+        raise FileNotFoundError(
             f"Could not find file {object_name} in {GOOGLE_ACL_DATA_BUCKET}"
         )
     return blob.download_as_string()


### PR DESCRIPTION
## What
`_download_blob_bytes` should raise FileNotFoundError if the blob to download doesn't exist

## Why

An error is raised: `'NoneType' object has no attribute 'download_as_string'`. But not the one that was expected: `FileNotFoundError: Could not find file <object_name> in <GOOGLE_ACL_DATA_BUCKET>`.

## How

## Remarks

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [requirements.txt](https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/master/requirements.txt#L17) if needed
